### PR TITLE
Docs 192

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,30 +33,32 @@ permalink: pretty
 logo: "/assets/images/FeatureBase-Logo-Gradient-Wide.png"
 
 color_scheme: featurebase # file URL: /_sass/color_schemes/featurebase.css
-
 # Enable or disable the site search
 # Supports true (default) or false
 search_enabled: true
-
-# Split pages into sections that can be searched individually
-# Supports 1 - 6, default: 2
-search.heading_level: 2
-
-# Maximum amount of previews per search result
-# Default: 3
-search.previews: 10
-
-# Maximum amount of words to display before a matched word in the preview
-# Default: 5
-search.preview_words_before: 5
-
-# Maximum amount of words to display after a matched word in the preview
-# Default: 10
-search.preview_words_after: 10
-
-# Enable or disable the search button that appears in the bottom right corner of every page
-# Supports true or false (default)
-search.button: true
+search:
+  # Split pages into sections that can be searched individually
+  # Supports 1 - 6, default: 2
+  heading_level: 2
+  # Maximum amount of previews per search result
+  # Default: 3
+  previews: 2
+  # Maximum amount of words to display before a matched word in the preview
+  # Default: 5
+  preview_words_before: 3
+  # Maximum amount of words to display after a matched word in the preview
+  # Default: 10
+  preview_words_after: 3
+  # Set the search token separator
+  # Default: /[\s\-/]+/
+  # Example: enable support for hyphenated search words
+  tokenizer_separator: /[\s/]+/
+  # Display the relative url in search results
+  # Supports true (default) or false
+  rel_url: true
+  # Enable or disable the search button that appears in the bottom right corner of every page
+  # Supports true or false (default)
+  button: false
 
 # For copy button on code
 enable_copy_code_button: true

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,10 @@ title: Featurebase help
 description: FeatureBase enables data engineers to process and operate on massive, continuously changing datasets in real time.
 theme: just-the-docs
 
+# WARNING: Do not change these settings without good reason to avoid breaking things
+# config.yml is heavily customized and will NOT update with changes from the source Just-the-docs repo
+# This means we need to check updates to the repo from time to time (so we can get things like copy button on code blocks, etc)
+
 url: https://github.com/FeatureBaseDB/featurebase-docs
 # remote_theme: "pmarsceill/just-the-docs"
 # url: https://just-the-docs.github.io
@@ -36,29 +40,31 @@ color_scheme: featurebase # file URL: /_sass/color_schemes/featurebase.css
 # Enable or disable the site search
 # Supports true (default) or false
 search_enabled: true
-search:
-  # Split pages into sections that can be searched individually
-  # Supports 1 - 6, default: 2
-  heading_level: 2
-  # Maximum amount of previews per search result
-  # Default: 3
-  previews: 2
-  # Maximum amount of words to display before a matched word in the preview
-  # Default: 5
-  preview_words_before: 3
-  # Maximum amount of words to display after a matched word in the preview
-  # Default: 10
-  preview_words_after: 3
-  # Set the search token separator
-  # Default: /[\s\-/]+/
-  # Example: enable support for hyphenated search words
-  tokenizer_separator: /[\s/]+/
-  # Display the relative url in search results
-  # Supports true (default) or false
-  rel_url: true
-  # Enable or disable the search button that appears in the bottom right corner of every page
-  # Supports true or false (default)
-  button: false
+
+# Split pages into sections that can be searched individually
+# Supports 1 - 6, default: 2
+search.heading_level: 2
+
+# Maximum amount of previews per search result
+# Default: 3
+search.previews: 10
+
+# Maximum amount of words to display before a matched word in the preview
+# Default: 5
+search.preview_words_before: 5
+
+# Maximum amount of words to display after a matched word in the preview
+# Default: 10
+search.preview_words_after: 10
+
+# Enable or disable the search button that appears in the bottom right corner of every page
+# Supports true or false (default)
+search.button: true
+
+# Set the search token separator
+# Default: /[\s\-/]+/
+# Example: enable support for hyphenated search words
+tokenizer_separator: /[\s/]+/
 
 # For copy button on code
 enable_copy_code_button: true

--- a/_includes/search_placeholder_custom.html
+++ b/_includes/search_placeholder_custom.html
@@ -1,0 +1,1 @@
+Search help

--- a/docs/community/old-setup/old-getting-started.md
+++ b/docs/community/old-setup/old-getting-started.md
@@ -156,7 +156,7 @@ molecula-consumer-csv \
     --files stargazer.csv
 ```
 
-Note that `--batch-size` is set to a larger value this time. Furthermore, as mentioned earlier, we are tracking not just which user starred a project, but also when they did it, with a time field. The last argument for the `stargazer` field, with the value of `YMD`, sets the field's [time quantum](/docs/concepts/old-glossary#time-quantum) (granularity) to year, month, day.
+Note that `--batch-size` is set to a larger value this time. Furthermore, as mentioned earlier, we are tracking not just which user starred a project, but also when they did it, with a time field. The last argument for the `stargazer` field, with the value of `YMD`, sets the field's [time quantum](/docs/concepts/time-quantums) (granularity) to year, month, day.
 
 
 ### Querying the data


### PR DESCRIPTION
fixed the search field text which was too long on some devices.
Now says "Search help" because it's fairly obvious the user is looking at FeatureBase help