### PR TITLE
mac safari clarify, gui to browser, version numbers, links to discord…

### DIFF
--- a/_includes/com-install/com-install-linux-source.md
+++ b/_includes/com-install/com-install-linux-source.md
@@ -12,7 +12,7 @@ There are two ways to download the release:
 
 | Method | Instructions | Destination |
 |---|---|---|
-| Browser | Download a [releases on GitHub](https://github.com/FeatureBaseDB/FeatureBase/releases){:target="_blank"}. | Default downloads directory |
+| Browser | Download a [release on GitHub](https://github.com/FeatureBaseDB/FeatureBase/releases){:target="_blank"}. | Default downloads directory |
 | Terminal | Substitute the version, kernel and processor in the following command:<br/>`curl -L https://github.com/FeatureBaseDB/featurebase/releases/download/v<version>/featurebase-v<version>-<kernel>-<processor>64.tar.gz -o featurebase.tgz` | featurebase.tgz |
 
 ### Step 2: Untar release files

--- a/_includes/com-install/com-install-linux-source.md
+++ b/_includes/com-install/com-install-linux-source.md
@@ -2,7 +2,7 @@
 
 * Open [FeatureBase releases on GitHub](https://github.com/FeatureBaseDB/FeatureBase/releases){:target="_blank"}
 * Make note of the:
-  * version (e.g., 3.30.0)
+  * version (e.g., 3.32.0)
   * kernel (darwin or linux)
   * processor (arm or amd)
 
@@ -12,7 +12,7 @@ There are two ways to download the release:
 
 | Method | Instructions | Destination |
 |---|---|---|
-| GUI | Click the installer to download. | Default downloads directory |
+| Browser | Download a [releases on GitHub](https://github.com/FeatureBaseDB/FeatureBase/releases){:target="_blank"}. | Default downloads directory |
 | Terminal | Substitute the version, kernel and processor in the following command:<br/>`curl -L https://github.com/FeatureBaseDB/featurebase/releases/download/v<version>/featurebase-v<version>-<kernel>-<processor>64.tar.gz -o featurebase.tgz` | featurebase.tgz |
 
 ### Step 2: Untar release files

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,8 +1,8 @@
 <!-- custom footer automatically appears at the bottom of each page -->
 
 <p>
-  <a href="https://discord.com/invite/bSBYjDbUUb?utm_campaign=FeatureBase_Launch&utm_source=Website&utm_medium=Community_page" target="_blank">Get support on the FeatureBase Discord channel</a> | <a href="https://github.com/FeatureBaseDB/featurebase-docs/issues" target="_blank">Raise a help issue </a> | <a href="https://www.featurebase.com/contact-us" target="_blank">Contact FeatureBase</a>
+  <a href="https://discord.gg/featurefirstai" target="_blank">Get support on the FeatureBase Discord channel</a> | <a href="https://github.com/FeatureBaseDB/featurebase-docs/issues" target="_blank">Raise a help issue </a> | <a href="https://www.featurebase.com/contact-us" target="_blank">Contact FeatureBase</a>
 </p>
 <p>
-  Copyright &copy; 2023 <a href="https://featurebase.com"" target="_blank" rel="noopener">FeatureBase</a>. All rights reserved.
+  Copyright &copy; 2023 <a href="https://featurebase.com" target="_blank" rel="noopener">FeatureBase</a>. All rights reserved.
 </p>

--- a/docs/cloud/cloud-databases/cloud-db-states.md
+++ b/docs/cloud/cloud-databases/cloud-db-states.md
@@ -30,7 +30,7 @@ nav_order: 4
 | FROZEN | There was a problem with backup and no new operations can be done on the database |
 | DEPROVISIONING |  A user has chosen to delete the database so the system is de-provisioning services and spinning the database down. | [Delete a cloud database](/docs/cloud/cloud-databases/cloud-db-delete) |
 | DELETED |  The state after deprovisioning completed successfully | [Delete a cloud database](/docs/cloud/cloud-databases/cloud-db-delete) |
-| FAILED | Database action has failed to complete successfully. Unrecoverable. Data is lost or Database failed to be provisioned. [Contact support on Discord for help](https://discord.gg/featurefirstai?utm_campaign=FeatureBase_Launch&utm_source=Website&utm_medium=Community_page){:target="_blank"} |
+| FAILED | Database action has failed to complete successfully. Unrecoverable. Data is lost or Database failed to be provisioned. [Contact support on Discord for help](https://discord.gg/featurefirstai){:target="_blank"} |
 
 
 ## Further information

--- a/docs/cloud/cloud-databases/cloud-db-states.md
+++ b/docs/cloud/cloud-databases/cloud-db-states.md
@@ -30,7 +30,7 @@ nav_order: 4
 | FROZEN | There was a problem with backup and no new operations can be done on the database |
 | DEPROVISIONING |  A user has chosen to delete the database so the system is de-provisioning services and spinning the database down. | [Delete a cloud database](/docs/cloud/cloud-databases/cloud-db-delete) |
 | DELETED |  The state after deprovisioning completed successfully | [Delete a cloud database](/docs/cloud/cloud-databases/cloud-db-delete) |
-| FAILED | Database action has failed to complete successfully. Unrecoverable. Data is lost or Database failed to be provisioned. [Contact support on Discord for help](https://discord.com/invite/bSBYjDbUUb?utm_campaign=FeatureBase_Launch&utm_source=Website&utm_medium=Community_page){:target="_blank"} |
+| FAILED | Database action has failed to complete successfully. Unrecoverable. Data is lost or Database failed to be provisioned. [Contact support on Discord for help](https://discord.gg/featurefirstai?utm_campaign=FeatureBase_Launch&utm_source=Website&utm_medium=Community_page){:target="_blank"} |
 
 
 ## Further information

--- a/docs/community/com-install-mac.md
+++ b/docs/community/com-install-mac.md
@@ -6,9 +6,9 @@ has_children: false
 nav_order: 2
 ---
 
-# How do I install FeatureBase Community on MacOS?
+# How do I install FeatureBase Community on macOS?
 
-Follow these instructions to install FeatureBase on a MacOS environment.
+Follow these instructions to install FeatureBase on a macOS environment.
 
 {% include /page-toc.md %}
 
@@ -16,11 +16,11 @@ Follow these instructions to install FeatureBase on a MacOS environment.
 
 * Learn about [FeatureBase Community](/docs/community/com-home)
 
-## Install FeatureBase
+## Install FeatureBase on macOS
 
 {% include /com-install/com-install-linux-source.md %}
 
-## Authorize FeatureBase with MacOS Gatekeeper system
+## Authorize FeatureBase with macOS Gatekeeper system
 
 {% include /com-install/com-issue-mac-gatekeeper-source.md %}
 

--- a/docs/community/com-startup-connect.md
+++ b/docs/community/com-startup-connect.md
@@ -11,20 +11,18 @@ These instructions explain how to run FeatureBase Community after you’ve insta
 
 {% include /page-toc.md %}
 
-{: .note }
-FeatureBase does not currently run on Mac Safari
-
 ## Before you begin
 
 * Learn about [FeatureBase Community](/docs/community/com-home)
+* Login to your system
 * Install FeatureBase on the system:
   * [Install FeatureBase on Linux](/docs/community/com-install-linux)
   * [Install FeatureBase on Mac](/docs/community/com-install-mac)
   * [Install FeatureBase on Windows](/docs/community/com-install-windows)
-* Login to your system
+
 
 {: .note}
-FeatureBase Community does not currently support Apple Safari. Install Mozilla Firefox or Google Chrome on your system instead.
+FeatureBase Community's UI does not currently support Apple Safari. Install Mozilla Firefox or Google Chrome on your system instead.
 
 ## Start the FeatureBase Community server
 

--- a/docs/community/old-setup/old-community-quickstart-guide.md
+++ b/docs/community/old-setup/old-community-quickstart-guide.md
@@ -18,12 +18,12 @@ In this demonstration you will:
 3. Restore two large-scale datasets into FeatureBase
 4. Run a set of analytics queries
 
->If you run into any roadblocks or have questions throughout the demonstration, please reach out to your FeatureBase representative or email se@featurebase.com.
+>If you run into any roadblocks or have questions, please join our [Discord](https://discord.gg/featurefirstai).
 
 ## Download FeatureBase Binary
 To download releases of FeatureBase, you must have a github account.
 
-You can see the latest FeatureBase release [here](https://github.com/FeatureBaseDB/featurebase/releases/latest)
+You can see the latest FeatureBase release [here](https://github.com/FeatureBaseDB/featurebase/releases/latest).
 
 >Please note that by downloading FeatureBase you agree to the [License](https://github.com/FeatureBaseDB/featurebase/blob/master/LICENSE-2.0.txt) and to receive occasional marketing emails from the FeatureBase team. You also understand that we will process your personal information in accordance with our [Privacy Policy](https://www.featurebase.com/privacy-policy/).
 
@@ -38,7 +38,7 @@ if there is a way to get this generic, please update! Seems like github as of 9/
 **Example for linux arm64:**
 
 ```
-wget https://github.com/FeatureBaseDB/featurebase/releases/latest/download/featurebase-community-v1.0.0-linux-arm64.tar.gz
+wget https://github.com/FeatureBaseDB/featurebase/releases/latest/download/featurebase-v3.32.0-linux-arm64.tar.gz
 ```
 
 
@@ -57,14 +57,14 @@ Next, extract the ```.tar.gz file``` , copy the FeatureBase binary located in th
 
 For the MacOS AMD64 Version:
 ```
-tar -zxvf featurebase-community-v1.0.0-darwin-amd64.tar.gz
-sudo cp ~/Downloads/featurebase-v3.20.0-darwin-amd64/featurebase /usr/local/bin/
+tar -zxvf featurebase-v3.32.0-darwin-amd64.tar.gz
+sudo cp ~/Downloads/featurebase-v3.32.0-darwin-amd64/featurebase /usr/local/bin/
 chmod ugo+x /usr/local/bin/featurebase
 ```
 For the MacOS ARM64 Version:
 ```
-tar -zxvf featurebase-community-v1.0.0-darwin-arm64.tar.gz
-sudo cp ~/Downloads/featurebase-v3.20.0-darwin-arm64/featurebase /usr/local/bin/
+tar -zxvf featurebase-v3.32.0-darwin-arm64.tar.gz
+sudo cp ~/Downloads/featurebase-v3.32.0-darwin-arm64/featurebase /usr/local/bin/
 chmod ugo+x /usr/local/bin/featurebase
 ```
 >**Note:** The copy or cp command above moves the FeatureBase binary to ```/usr/local/bin/```.
@@ -140,9 +140,9 @@ First, download the appropriate binary for your system [here](https://github.com
 Next, extract the ```.tar.gz file``` , copy the featurebase binary located in the ```featurebase=<version_architecture>/``` directory in the extract to your ```/usr/local/bin folder```, and make it executable.
 
 ```
-tar -zxvf featurebase-community-v1.0.0-linux-arm64.tar.gz
-chmod +x featurebase-v3.20.0-linux-arm64/featurebase
-sudo cp featurebase-v3.20.0-linux-arm64/featurebase /usr/local/bin
+tar -zxvf featurebase-v3.32.0-linux-arm64.tar.gz
+chmod +x featurebase-v3.32.0-linux-arm64/featurebase
+sudo cp featurebase-v3.32.0-linux-arm64/featurebase /usr/local/bin
 ```
 
 >**Note:** The copy or ```cp``` command above moves the ```featurebase``` binary to /usr/local/bin/. Ensure this folder is in your path variable by, running ```echo $PATH``` in the command line and confirming ```/usr/local/bin/``` is there. If it's not, run ```export PATH=$PATH:/usr/local/bin``` to append it to your path variable.


### PR DESCRIPTION
* /docs/community/com-startup-connect/ says featurebase does not current run on Mac Safari…which is duplicated below.
* Download the release says GUI click the installer…will likely change to Browser…use this link to download the current release
* Various changes to version numbers and formatting on /docs/community/old-setup/old-community-quickstart-guide/
* Changing all links to Discord to be: https://discord.gg/featurefirstai