### PR TITLE
fb-2013 remove references to deprecated --sql.sqlendpoint-enabled flag

### DIFF
--- a/docs/community/com-config/com-config-cli-enable-sql-endpoint.md
+++ b/docs/community/com-config/com-config-cli-enable-sql-endpoint.md
@@ -13,7 +13,7 @@ The SQL endpoint allows you to execute SQL statements:
 
 ## Before you begin
 
-* [Start the FeatureBase Community server](/docs/community/com-startup-connect) with the `--sql.endpoint-enabled` flag
+* [Start the FeatureBase Community server](/docs/community/com-startup-connect)
 * CD to the `/featurebase/opt` directory
 
 ## Start the FeatureBase SQL CLI

--- a/docs/community/com-startup-connect.md
+++ b/docs/community/com-startup-connect.md
@@ -31,7 +31,7 @@ FeatureBase Community's UI does not currently support Apple Safari. Install Mozi
 * Run the following command:
 
 ```
-./featurebase server --sql.endpoint-enabled
+./featurebase server
 ```
 
 ## Confirm FeatureBase server is running

--- a/docs/sql-guide/functions/function-totimestamp.md
+++ b/docs/sql-guide/functions/function-totimestamp.md
@@ -108,7 +108,8 @@ insert into demo(_id, int_ts)
 insert into demo(_id, int_ts)
     values (3, 86400000);
 
-select _id, int_ts, TOTIMESTAMP(int_ts, 's') as ts from demo;
+select _id, int_ts, TOTIMESTAMP(int_ts, 's') as ts 
+from demo;
 
  _id |   int_ts | ts                            
 -----+----------+-------------------------------
@@ -116,7 +117,10 @@ select _id, int_ts, TOTIMESTAMP(int_ts, 's') as ts from demo;
    2 |    86400 | 1970-01-02 00:00:00 +0000 UTC 
    3 | 86400000 | 1972-09-27 00:00:00 +0000 UTC 
 
-select _id, int_ts, TOTIMESTAMP(int_ts, 's') as ts from demo where TOTIMESTAMP(int_ts, 's')>'1970-01-02T00:00:00Z';
+select _id, int_ts, TOTIMESTAMP(int_ts, 's') as ts 
+from demo 
+where TOTIMESTAMP(int_ts, 's')>'1970-01-02T00:00:00Z';
+
  _id |   int_ts | ts                            
 -----+----------+-------------------------------
    3 | 86400000 | 1972-09-27 00:00:00 +0000 UTC 


### PR DESCRIPTION
This PR removes references to deprecated --sql.sqlendpoint-enabled flag and does some minor formatting.