### PR TITLE
Quick fix to rename plugin

### DIFF
--- a/docs/community/com-query/old-grafana-connector.md
+++ b/docs/community/com-query/old-grafana-connector.md
@@ -33,7 +33,7 @@ plugins = /path/to/grafana-plugin/molecula/dist
 Uncomment and add the plugin id to `allow_loading_unsigned_plugins`:
 
 ```
-allow_loading_unsigned_plugins = molecula-datasource
+allow_loading_unsigned_plugins = featurebase-datasource
 ```
 
 The port which defaults to `3000` can be modified by setting the `http_port` field if necessary.


### PR DESCRIPTION
There are few features being built right now. The grafana page might need a clean up after those. 

This patch is to let users know that the name of the plugin is changed. 