### PR TITLE
Document STREAMX and its corresponding fbsql \file meta-command

### DIFF
--- a/docs/sql-guide/functions/function-tuple.md
+++ b/docs/sql-guide/functions/function-tuple.md
@@ -74,7 +74,7 @@ B,2014-07-15T01:18:46Z,stringset2, 2
 with
     BATCHSIZE 10000
     format 'CSV'
-    input 'STREAM';
+    input 'INLINE';
 
 ```
 

--- a/docs/sql-guide/statements/statement-insert-bulk.md
+++ b/docs/sql-guide/statements/statement-insert-bulk.md
@@ -56,7 +56,7 @@ BULK INSERT
     [
       [BATCHSIZE integer_literal]
       [ROWSLIMIT integer_literal]
-      [INPUT ['path/file_name' | 'URL' | 'STREAM']]
+      [INPUT ['path/file_name' | 'INLINE' | 'STREAMX' |'URL']]
       [FORMAT
         ['CSV' [HEADER_ROW] [CSV_EMPTY_STRING_AS_NULL] [CSV_NULL_AS_NULL] [NULL_AS_EMPTY_SET]] |
         ['NDJSON' [ALLOW_MISSING_VALUES] [NULL_AS_EMPTY_SET]] |
@@ -80,13 +80,13 @@ BULK INSERT
 | `FROM` | A single or multi-line string literal that specifies the source of data and are interpreted based on the INPUT option. | Yes |  |
 | `'path/file_name'` | Valid path and file name for data source. | Optional | Not available for FeatureBase Cloud. |
 | `'URL'` | Valid URL for data source. | Optional |  |
-| `x'records'` | CSV or NDJSON records as a string literal. | Required for STREAM | Not supported for `FORMAT 'PARQUET'` |
+| `x'records'` | CSV or NDJSON records as a string literal. | Required for INLINE | Not supported for `FORMAT 'PARQUET'` |
 | `WITH` | Pass one or more statement level options. | Optional |  |
 | `BATCHSIZE` | Specify the batch size of the BULK commit. Defaults to 1000. | Optional |  |
 | `ROWSLIMIT` | Limit the number of rows processed in a batch. | Optional |  |
-| `INPUT` | Input values must match those used in the `FROM` clause |  |  |
-| `'STREAM'` | The contents of the literal read as though they were in a file.  | Required for `FROM x'records'`<br/>Not supported for `PARQUET` Format | [STREAM quotation marks](#using-stream-with-quotation-marks) |
-| `FORMAT` | Set the format of the source data to `'CSV'`, `'NDJSON'` or `'PARQUET'` | Optional | `'PARQUET'` does not support `INPUT (STREAM)` |
+| `INPUT` | Input values must match those used in the `FROM` clause |  | `STREAM` has been replaced by `INLINE` to better describe its use. `STREAMX` is new functionality which supports a streaming payload using an http multipart POST. See [fbsql](/docs/tools/fbsql/fbsql-home/) for an implemetation of its use. `STREAMX` will eventually be renamed `STREAM`. |
+| `'INLINE'` | The contents of the literal read as though they were in a file.  | Required for `FROM x'records'`<br/>Not supported for `PARQUET` Format | [INLINE quotation marks](#using-inline-with-quotation-marks) |
+| `FORMAT` | Set the format of the source data to `'CSV'`, `'NDJSON'` or `'PARQUET'` | Optional | `'PARQUET'` does not support `INPUT (INLINE)` |
 | `NULL_AS_EMPTY_SET` | Argument that will coerce all `NULL` values resulting from the `MAP` clause into `[]` (empty sets) for all target columns with `SET` datatypes | Optional |  |
 | `HEADER_ROW` | `CSV` argument that will ignore the header in the source CSV file. | Optional |  |
 | `CSV_EMPTY_STRING_AS_NULL` | `CSV` argument that will assign `""` value as `null` | Optional |  |
@@ -157,17 +157,17 @@ TRANSFORM (
 ```
 ### FROM examples
 
-#### Using STREAM argument
+#### Using INLINE argument
 
-The contents of an inline stream string literal are treated as a file and read line-by-line.
+The contents of an inline string literal are treated as a file and read line-by-line.
 
-Single line stream string literal
+Single line string literal
 
 ```
 'this is a single-line string literal'
 ```
 
-Multi-line stream string literal
+Multi-line string literal
 
 Multi line (prepend with `x`)
 
@@ -180,7 +180,7 @@ string
 literal'
 ```
 
-#### Using STREAM with quotation marks
+#### Using INLINE with quotation marks
 
 FROM clause quotation marks must be escaped before the BULK statement is run, even when CSV values are quoted.
 

--- a/docs/sql-guide/statements/statement-insert-bulk.md
+++ b/docs/sql-guide/statements/statement-insert-bulk.md
@@ -84,7 +84,7 @@ BULK INSERT
 | `WITH` | Pass one or more statement level options. | Optional |  |
 | `BATCHSIZE` | Specify the batch size of the BULK commit. Defaults to 1000. | Optional |  |
 | `ROWSLIMIT` | Limit the number of rows processed in a batch. | Optional |  |
-| `INPUT` | Input values must match those used in the `FROM` clause |  | `STREAM` has been replaced by `INLINE` to better describe its use. `STREAMX` is new functionality which supports a streaming payload using an http multipart POST. See [fbsql](/docs/tools/fbsql/fbsql-home/) for an implemetation of its use. `STREAMX` will eventually be renamed `STREAM`. |
+| `INPUT` | Input values must match those used in the `FROM` clause |  | `STREAM` has been replaced by `INLINE` to better describe its use. `STREAMX` is new functionality which supports a streaming payload using an http multipart POST. See [fbsql](/docs/tools/fbsql/fbsql-home/) for an implementation of its use. `BATCHSIZE` is honored with `STREAMX` as it batches records according to that value as the stream of records is received by the server. There's no batching on the client. `STREAMX` will eventually be renamed `STREAM`. |
 | `'INLINE'` | The contents of the literal read as though they were in a file.  | Required for `FROM x'records'`<br/>Not supported for `PARQUET` Format | [INLINE quotation marks](#using-inline-with-quotation-marks) |
 | `FORMAT` | Set the format of the source data to `'CSV'`, `'NDJSON'` or `'PARQUET'` | Optional | `'PARQUET'` does not support `INPUT (INLINE)` |
 | `NULL_AS_EMPTY_SET` | Argument that will coerce all `NULL` values resulting from the `MAP` clause into `[]` (empty sets) for all target columns with `SET` datatypes | Optional |  |

--- a/docs/tools/fbsql/fbsql-home.md
+++ b/docs/tools/fbsql/fbsql-home.md
@@ -123,6 +123,29 @@ Lists the views in the database your are connected to.
 
 Prints the argument to standard output, followed by a newline.
 
+####  local file reference
+
+```shell
+\file filename [alias]
+```
+
+Adds a reference to `filename` to the the query buffer. An optional alias can be provided in order to simplify referencing a long or complex file name.
+
+Local file references can be use in [BULK INSERT](/docs/sql-guide/statements/statement-insert-bulk/) statements with `INPUT STREAMX`. For example, the following commands will insert contents from local file `insert_test.csv` using an alias `icsv`:
+
+```
+fbsql=# \file insert_test.csv icsv
+fbsql-# bulk replace
+     -#     into insert_test (_id, int1, string1, timestamp1)
+     -#     map (0 id, 1 int, 2 string)
+     -#     transform (@0, @1, @2, current_timestamp)
+     -# from
+     -#     'icsv'
+     -# with
+     -#     format 'CSV'
+     -#     input 'STREAMX';
+```
+
 ####  use a file for commands
 
 ```shell


### PR DESCRIPTION
This commit also changes `STREAM` to `INLINE` since that's what we're moving toward.