### PR TITLE
Documentation for OFFSET function

### DIFF
--- a/docs/sql-guide/functions/function-offset.md
+++ b/docs/sql-guide/functions/function-offset.md
@@ -30,23 +30,28 @@ The `OFFSET()` function doesn't have a direct return value. It affects the resul
 
 ## Examples
 
-### using OFFSET to skip rows
+### Colors table
+
+This table is used in subsequent OFFSET() queries.
 
 ```sql
 create table colors
     (_id id, color string);
 
-insert into segments(_id,color)
+insert into colors(_id,color)
     values (1,'green')
-insert into segments(_id,color)
+insert into colors(_id,color)
     values (2,'red')
-insert into segments(_id,color)
+insert into colors(_id,color)
     values (3,'yellow')
-insert into segments(_id,color)
+insert into colors(_id,color)
     values (4,'blue')
-insert into segments(_id,color)
+insert into colors(_id,color)
     values (5,'orange')
+```    
+### In this example, the OFFSET 3 clause skips the first three rows, and the LIMIT 2 clause fetches the next two rows from the "colors" table.
 
+```sql
 
 select * from colors limit 2 offset 3;
 +-----+--------+
@@ -56,26 +61,10 @@ select * from colors limit 2 offset 3;
 +-----+--------+
 |   5 | orange |  
 +-----+--------+
-In this example, the OFFSET 3 clause skips the first three rows, and the LIMIT 2 clause fetches the next two rows from the "colors" table.
 ```
-### returning all the rows after OFFSET
+### By using LIMIT -1, the query returns all the rows starting from the offset specified (in this case, the third row) until the end of the result set.
 
 ```sql
-create table colors
-    (_id id, color string);
-
-insert into segments(_id,color)
-    values (1,'green')
-insert into segments(_id,color)
-    values (2,'red')
-insert into segments(_id,color)
-    values (3,'yellow')
-insert into segments(_id,color)
-    values (4,'blue')
-insert into segments(_id,color)
-    values (5,'orange')
-
-
 select * from colors limit -1 offset 2;
 +-----+--------+
 | _id | color  |
@@ -86,5 +75,4 @@ select * from colors limit -1 offset 2;
 +-----+--------+
 |   5 | orange |  
 +-----+--------+
-By using LIMIT -1, the query returns all the rows starting from the offset specified (in this case, the third row) until the end of the result set.
 ```

--- a/docs/sql-guide/functions/function-offset.md
+++ b/docs/sql-guide/functions/function-offset.md
@@ -1,0 +1,90 @@
+---
+title: OFFSET()
+layout: default
+parent: SQL functions
+grand_parent: SQL guide
+---
+
+# RTRIM () function
+
+`OFFSET()` function is used in conjuction with the `LIMIT` clause to control the starting point of data retrieval in a SQL query result. It allows skipping a specified number of rows before fetching the desired number of rows.
+
+## Syntax
+
+```
+limit(num_of_rows) Offset(offset_value)
+```
+
+## Arguments
+
+| Argument | Description |
+|---|---|
+| `num_of_rows` | An `integer` value specifying the maximum number of rows to fetch. |
+| `offset_value` | An `integer` value specifying the number of rows to skip. |
+
+
+## Returns
+
+The `OFFSET()` function doesn't have a direct return value. It affects the result set returned by the SQL query by skipping the specified number of rows before fetching the data.
+
+
+## Examples
+
+### using OFFSET to skip rows
+
+```sql
+create table colors
+    (_id id, color string);
+
+insert into segments(_id,color)
+    values (1,'green')
+insert into segments(_id,color)
+    values (2,'red')
+insert into segments(_id,color)
+    values (3,'yellow')
+insert into segments(_id,color)
+    values (4,'blue')
+insert into segments(_id,color)
+    values (5,'orange')
+
+
+select * from colors limit 2 offset 3;
++-----+--------+
+| _id | color  |
++-----+--------+
+|   4 | blue   |  
++-----+--------+
+|   5 | orange |  
++-----+--------+
+In this example, the OFFSET 3 clause skips the first three rows, and the LIMIT 2 clause fetches the next two rows from the "colors" table.
+```
+### returning all the rows after OFFSET
+
+```sql
+create table colors
+    (_id id, color string);
+
+insert into segments(_id,color)
+    values (1,'green')
+insert into segments(_id,color)
+    values (2,'red')
+insert into segments(_id,color)
+    values (3,'yellow')
+insert into segments(_id,color)
+    values (4,'blue')
+insert into segments(_id,color)
+    values (5,'orange')
+
+
+select * from colors limit -1 offset 2;
++-----+--------+
+| _id | color  |
++-----+--------+
+|   3 | yellow |  
++-----+--------+
+|   4 | blue   |  
++-----+--------+
+|   5 | orange |  
++-----+--------+
+By using LIMIT -1, the query returns all the rows starting from the offset specified (in this case, the third row) until the end of the result set.
+```


### PR DESCRIPTION
The OFFSET() function is used in conjunction with the LIMIT clause to control the starting point of data retrieval in a SQL query result. It allows skipping a specified number of rows before fetching the desired number of rows.