### PR TITLE
CLOUD-1649 - Update docs framework for deprecation of set-output command fix

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3
-      - run: bundle exec jekyll build --baseurl ${{ steps.pages.outputs.base_path }} # defaults output to '/_site'
+      - run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}" # defaults output to '/_site'
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1 # This will automatically upload an artifact from the '/_site' directory
 


### PR DESCRIPTION
Updating `actions/configure-pages@v1` to `actions/configure-pages@v3` in previous PR (https://github.com/FeatureBaseDB/featurebase-docs/pull/170) caused errors so I looked around and found the sample starter workflow page that uses `actions/configure-pages@v3` here: https://github.com/actions/starter-workflows/blob/2bb20df369386c3e20630fce032d3ab4915373a1/pages/jekyll.yml#L47.
In that sample file, they surrounded the base path with quotes (line 47). Hopefully, adding these quotes will solve our errors.