### PR TITLE
Fbsql fixarama

### DIFF
--- a/_includes/cloud-auth/cloud-auth-api-summary.md
+++ b/_includes/cloud-auth/cloud-auth-api-summary.md
@@ -1,3 +1,3 @@
 An API key allows you to connect to your FeatureBase database:
 * via the Cloud REST API
-* via the FBSQL command-line SQL query tool
+* via the fbsql command-line SQL query tool

--- a/_includes/community/com-sql-query-run.md
+++ b/_includes/community/com-sql-query-run.md
@@ -3,6 +3,6 @@
 | CLI | Run SQL statements from the FeatureBase CLI system | [Enable SQL CLI](/docs/community/com-config/com-config-sql-cli-enable) |
 | FeatureBase API | FeatureBase provides an API which can be used to execute PQL statements | [Community API](/docs/community/com-api/com-api-home) |
 | HTTPS | Run SQL statements over HTTPS using the SQL CLI | [Enable SQL CLI](/docs/community/com-api/old-sql-endpoint)
-| FBSQL CLI tool | SQL statements can be run via the FBSQL terminal tool | [FBSQL terminal tool](/docs/tools/fbsql/fbsql-home)|
+| fbsql CLI tool | SQL statements can be run via the fbsql terminal tool | [fbsql terminal tool](/docs/tools/fbsql/fbsql-home)|
 | FeatureBase Query editor | FeatureBase Community comes with built-in Query editor | [FeatureBase Query editor](/docs/community/com-query/com-query-home#featurebase-query-editor) |
 | FeatureBase Query builder | FeatureBase Community comes with built-in Query builder | [FeatureBase Query editor](/docs/community/com-query/com-query-home#featurebase-query-builder) |

--- a/_includes/fbsql/fb-db-create.md
+++ b/_includes/fbsql/fb-db-create.md
@@ -1,3 +1,3 @@
-* Setup a FeatureBase database
-  * [Setup a FeatureBase Cloud database](/docs/cloud/cloud-databases/cloud-db-manage)
-  * [Setup a FeatureBase Community database](/docs/community/com-db/com-db-manage)
+* Create a FeatureBase database
+  * [Create a FeatureBase Cloud database](/docs/cloud/cloud-databases/cloud-db-manage)
+  * [Create a FeatureBase Community database](/docs/community/com-db/com-db-manage)

--- a/_includes/fbsql/fbsql-before-begin.md
+++ b/_includes/fbsql/fbsql-before-begin.md
@@ -1,3 +1,3 @@
 * [Learn about "docopt" notation standards used in this guide](http://docopt.org/){:target="_blank"}
-* [Learn about FBSQL](/docs/tools/fbsql/fbsql-home)
-* [Install FBSQL](/docs/tools/fbsql/fbsql-install)
+* [Learn about fbsql](/docs/tools/fbsql/fbsql-home)
+* [Install fbsql](/docs/tools/fbsql/fbsql-install)

--- a/_includes/fbsql/fbsql-flags-execution-extra.md
+++ b/_includes/fbsql/fbsql-flags-execution-extra.md
@@ -1,4 +1,4 @@
 ### Flag execution
 
 * Flags can be executed individually or as a sequence delimited by `\`
-* Use single quotation marks `  ` to insert whitespace
+* Use single quotation marks `' '` to insert whitespace

--- a/_includes/fbsql/fbsql-help-quit.md
+++ b/_includes/fbsql/fbsql-help-quit.md
@@ -1,3 +1,3 @@
 {: .note}
 > Enter `fbsql --help` at the CLI to list available commands.
->`\q` quits the FBSQL interface.
+>`\q` quits the fbsql interface.

--- a/_includes/fbsql/fbsql-interface-run-file-content.md
+++ b/_includes/fbsql/fbsql-interface-run-file-content.md
@@ -1,1 +1,1 @@
-|`[i|include] <filename.sql>` | Run SQL statements from file | Equivalent to `fbsql --file` command |
+|`[i|include] <filename>` | Run content from file which can include valid meta-commands and SQL queries | Equivalent to `fbsql --file` command |

--- a/_includes/fbsql/fbsql-load-sql-file-arg.md
+++ b/_includes/fbsql/fbsql-load-sql-file-arg.md
@@ -1,3 +1,3 @@
 | Argument | Description | Additional information |
 |---|---|---|---|
-| `-[f|-file] <filename>`| Run SQL contained in `<filename>` | [Run SQL in fbsql](/docs/tools/fbsql/fbsql-running-sql) |
+| `-[f|-file] <filename>`| Run content from file which can include valid meta-commands and SQL queries | equivalent to `[i|include <filename>]` meta-command |

--- a/_includes/fbsql/fbsql-load-sql-file-arg.md
+++ b/_includes/fbsql/fbsql-load-sql-file-arg.md
@@ -1,3 +1,3 @@
 | Argument | Description | Additional information |
 |---|---|---|---|
-| `-[f|-file] <filename>`| Run SQL contained in `<filename>` | [Run SQL in FBSQL](/docs/tools/fbsql/fbsql-running-sql) |
+| `-[f|-file] <filename>`| Run SQL contained in `<filename>` | [Run SQL in fbsql](/docs/tools/fbsql/fbsql-running-sql) |

--- a/_includes/fbsql/fbsql-output-flags-summary.md
+++ b/_includes/fbsql/fbsql-output-flags-summary.md
@@ -1,0 +1,4 @@
+fbsql output can be configured from the command-line or fbsql interface to:
+* direct CLI and interface history to a new directory
+* change the working directory
+* create a file to output SQL query results and comments

--- a/_includes/fbsql/fbsql-prefix-cli-flags.md
+++ b/_includes/fbsql/fbsql-prefix-cli-flags.md
@@ -1,8 +1,8 @@
 ## CLI flag Prefix
 
-Commands can be executed from the CLI or FBSQL interface using the appropriate prefix:
+Commands can be executed from the CLI or fbsql interface using the appropriate prefix:
 
 | Interface | Prefix | Additional information |Example |
 |---|---|---|
 | CLI | `fbsql` | `fbsql --config=cloud-user-connect.toml` |
-| FBSQL | `\!` | `\! --config=cloud-user-connect.toml` |
+| fbsql | `\!` | `\! --config=cloud-user-connect.toml` |

--- a/_includes/fbsql/fbsql-prefix-cli-flags.md
+++ b/_includes/fbsql/fbsql-prefix-cli-flags.md
@@ -2,7 +2,7 @@
 
 Commands can be executed from the CLI or fbsql interface using the appropriate prefix:
 
-| Interface | Prefix | Additional information |Example |
+| Interface | Prefix | Example |
 |---|---|---|
 | CLI | `fbsql` | `fbsql --config=cloud-user-connect.toml` |
 | fbsql | `\!` | `\! --config=cloud-user-connect.toml` |

--- a/_includes/fbsql/fbsql-prefix-meta-flags.md
+++ b/_includes/fbsql/fbsql-prefix-meta-flags.md
@@ -5,4 +5,4 @@ Meta-command flags can be run from the fbsql interface or CLI using an appropria
 | Interface | Prefix | Description | Example |
 |---|---|---|---|
 | fbsql | `\` | Execute one or more meta-command flags and arguments separated by `\` backslash characters | `\print \echo "this is a test"` |
-| CLI | `fbsql -[c|-command]` | Meta-command flags enclosed in single or double quotes are executed without opening the fbsql interface | `fbsql --command '\print \echo this is a test'` |
+| CLI | `fbsql [-c|--command]` | Meta-command flags enclosed in single or double quotes are executed without opening the fbsql interface | `fbsql --command '\print \echo this is a test'` |

--- a/_includes/fbsql/fbsql-prefix-meta-flags.md
+++ b/_includes/fbsql/fbsql-prefix-meta-flags.md
@@ -4,5 +4,5 @@ Meta-command flags can be run from the fbsql interface or CLI using an appropria
 
 | Interface | Prefix | Description | Example |
 |---|---|---|---|
-| fbsql | `\` | Execute one or more meta-command flags and arguments separated by `\` backslash characters | `\print \echo "this is a test"` |
+| fbsql | `\` | Leading backslash followed by one or more meta-command flags and arguments separated by `\` backslash characters. | `\print \echo "this is a test"` |
 | CLI | `fbsql [-c|--command]` | Meta-command flags enclosed in single or double quotes are executed without opening the fbsql interface | `fbsql --command '\print \echo this is a test'` |

--- a/_includes/fbsql/fbsql-prefix-meta-flags.md
+++ b/_includes/fbsql/fbsql-prefix-meta-flags.md
@@ -1,8 +1,8 @@
 ## Meta-command flag prefix
 
-Meta-command flags can be run from the FBSQL interface or CLI using an appropriate prefix:
+Meta-command flags can be run from the fbsql interface or CLI using an appropriate prefix:
 
 | Interface | Prefix | Description | Example |
 |---|---|---|---|
-| FBSQL | `\` | Execute one or more meta-command flags and arguments separated by `\` backslash characters | `\print \echo "this is a test"` |
-| CLI | `fbsql -[c|-command]` | Meta-command flags enclosed in single or double quotes are executed without opening the FBSQL interface | `fbsql --command '\print \echo this is a test'` |
+| fbsql | `\` | Execute one or more meta-command flags and arguments separated by `\` backslash characters | `\print \echo "this is a test"` |
+| CLI | `fbsql -[c|-command]` | Meta-command flags enclosed in single or double quotes are executed without opening the fbsql interface | `fbsql --command '\print \echo this is a test'` |

--- a/_includes/fbsql/fbsql-query-buffer-extra.md
+++ b/_includes/fbsql/fbsql-query-buffer-extra.md
@@ -1,4 +1,4 @@
-### FBSQL query buffer
+### fbsql query buffer
 
 The **query buffer** holds partial or not executed:
 * meta-commands

--- a/_includes/fbsql/fbsql-query-formatting-summary.md
+++ b/_includes/fbsql/fbsql-query-formatting-summary.md
@@ -1,0 +1,5 @@
+`PSET` (Print Set) meta-commands alter default output formatting for SQL queries for:
+* border
+* orientation
+* query result timestamp
+* toggling storage of results as variables that can be reused

--- a/_includes/fbsql/fbsql-status-table.md
+++ b/_includes/fbsql/fbsql-status-table.md
@@ -1,6 +1,6 @@
-### FBSQL status
+### fbsql status
 
-FBSQL displays status information at startup:
+fbsql displays status information at startup:
 
 | Status | Description | Additional information |
 |---|---|---|

--- a/_includes/fbsql/fbsql-toml-connection-file-extra.md
+++ b/_includes/fbsql/fbsql-toml-connection-file-extra.md
@@ -1,8 +1,8 @@
-### TOML connection file
+### Connection file
 
-A `filename.toml` connection file can be saved in the `*/fbsql/featurebase` directory or in an accessible file path.
+You can setup a file containing connection details in the `*/fbsql/featurebase` directory or in an accessible file path.
 
-Valid connection files have:
+Connections files have a `.toml` extension and contain:
 * a valid combination of arguments and values in form `argument = "value"`,
 * on individual lines,
 * with leading `--` and trailing `\` omitted.

--- a/docs/cloud/cloud-authentication/cloud-auth-create-key.md
+++ b/docs/cloud/cloud-authentication/cloud-auth-create-key.md
@@ -34,4 +34,4 @@ The API key ID and Secret are displayed **only** when created. They are **not** 
 
 * [Cloud API reference](https://api-docs-featurebase-cloud.redoc.ly){:target="_blank"}
 * [Create key API reference](https://api-docs-featurebase-cloud.redoc.ly/latest#operation/postKey){:target="_blank"}
-* [Learn about the FBSQL command-line SQL query tool](/docs/tools/fbsql/fbsql-home)
+* [Learn about the fbsql command-line SQL query tool](/docs/tools/fbsql/fbsql-home)

--- a/docs/cloud/cloud-authentication/cloud-auth-manage.md
+++ b/docs/cloud/cloud-authentication/cloud-auth-manage.md
@@ -39,4 +39,4 @@ has_toc: false
 ## Further information
 
 * [API keys HTTP API reference](https://api-docs-featurebase-cloud.redoc.ly/latest#tag/Keys)
-* [FBSQL command-line query editor](/docs/tools/fbsql/fbsql-home)
+* [fbsql command-line query editor](/docs/tools/fbsql/fbsql-home)

--- a/docs/cloud/cloud-db-connect/cloud-db-connect.md
+++ b/docs/cloud/cloud-db-connect/cloud-db-connect.md
@@ -13,7 +13,7 @@ There are several methods to connect to your database:
 
 * via the web portal
 * via REST API calls used in applications
-* via FBSQL, a command-line SQL tool you can install on a local Linux or MacOS machine
+* via fbsql, a command-line SQL tool you can install on a local Linux or MacOS machine
 
 ## Before you begin
 
@@ -30,10 +30,10 @@ The Cloud API allows two methods to authenticate with your FeatureBase Cloud dat
 * [Cloud API security JWT access token](https://api-docs-featurebase-cloud.redoc.ly/latest#section/Security){:target="_blank"}
 * [Cloud API key](/docs/cloud/cloud-authentication/cloud-auth-manage)
 
-## Connect via FBSQL command-line query editor
+## Connect via fbsql command-line query editor
 
-You can connect to your FeatureBase database and run SQL statements using the FBSQL command line tool.
+You can connect to your FeatureBase database and run SQL statements using the fbsql command line tool.
 
-FBSQL connections require a registered user account, or a Cloud API-Key
+fbsql connections require a registered user account, or a Cloud API-Key
 
-* [Learn more about FBSQL](/docs/tools/fbsql/fbsql-home)
+* [Learn more about fbsql](/docs/tools/fbsql/fbsql-home)

--- a/docs/community/com-tables/com-table-manage.md
+++ b/docs/community/com-tables/com-table-manage.md
@@ -28,7 +28,7 @@ FeatureBase Community supports the following SQL statements to create and alter 
 You can run these statements using any of the following methods:
 
 * [Learn about the built-in query editor and query builder](/docs/community/com-query/com-query-home)
-* [Learn how to use the FBSQL CLI tool](/docs/tools/fbsql/fbsql-home)
+* [Learn how to use the fbsql CLI tool](/docs/tools/fbsql/fbsql-home)
 * [Learn how to create and manage tables using the API](/docs/community/com-api/com-api-home)
 
 ## Create tables when importing data

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -19,14 +19,13 @@ fbsql output can be configured from the command-line or fbsql interface.
 ## Syntax
 
 ```
-
-[ (<meta-prefix>)
-    <history-logs> |
-    <file-output> |
-    <write-text-to-output>
-] |
-[ (<pset-prefix>)
-    <pset-output-flags>
+(<meta-prefix>)
+  [--history-path="<directory-name>"] |
+  [cd [<directory-name>]] |
+  [[i|include] <filename.sql>]
+  [[o | out] <query-output-filename>] |
+  [qecho <text>] |
+  [warn <text>]
 ]
 ```
 
@@ -54,127 +53,13 @@ fbsql output can be configured from the command-line or fbsql interface.
 | `qecho <text>` | Output `<text>` to file defined by `\[o|output <output-filename>]` |
 | `warn <text>` | Output `<text>` to fbsql standard error channel |
 
-## PSET prefix
-
-PSET flags can be executed from the CLI or fbsql interface:
-
-| Interface | Prefix | Structure | Example |
-|---|---|---|---|
-| CLI | `fbsql [-P|--pset] <pset-meta-commands>` | PSET output flags structured as `flag="value"` | `fbsql --P border="1"` |
-| fbsql | `\pset <pset-meta-commands>` | Valid sequence of PSET output flag, argument and value if required | `\pset border 2` |
-
-## PSET output flags
-
-| Flags | Description | Default | Additional information |
-|---|---|---|---|
-| `border [0...3]` | Border for table output | 1 | [PSET border values](#pset-query-border-values) |
-| `format [aligned | csv]` | Toggle query result format from column, row format to RFC 4180 standard CSV format | Aligned | [Query output format](#pset-query-result-orientation) |
-| `location ['<tz-identifier>']` | Location for query result timestamps | local time zone | [Timezone identifier](#pset-time-zone-identifier)
-| `[t | tuples_only]` | Toggle storage of multiple values in a single variable. | off | [Tuples additional](#pset-tuples) |
-
 ## Additional information
 
 {% include /fbsql/fbsql-flags-execution-extra.md %}
 
 {% include /fbsql/fbsql-query-buffer-extra.md %}
 
-### PSET defaults
-
-```
-border      1
-expanded    off
-format      aligned
-location    Local
-tuples_only off
-```
-
-### PSET query border values
-
-| Value | Table border | Additional information |
-|---|---|---|
-| 0 | None | Default |
-| 1 | Internal dividing lines |  |
-| 2 | Table frame |  |
-| 3 | Latex format dividing lines between rows if Add latex format dividing lines between rows | Requires Latex |
-
-### PSET query result orientation
-
-{: .note}
-`\x [on | off]` can also be used to change result orientation
-
-| Value | Column name | Data |
-|---|---|
-| on | Left column | Right column |
-| off | Top row | Bottom rows |
-
-### PSET CSV output format
-
-* Titles and footers are not printed.
-* Header line with column names generated when `tuples_only` parameter is `off`
-* End of line characters are system-dependent:
-
-| OS | Description |EOL character |
-|---|---|---|
-| Linux<br/>MacOS | Single new-line character | `\n` |
-| Windows | Carriage return and newline sequence |`\r\n` |
-
-### PSET time-zone identifier
-
-The optional time-zone can be set as follows:
-
-| `<tz identifier>` | Description | Further information |
-|---|---|---|
-| `<none>` | Local time |  |
-| `UTC` | UTC time |  |
-| `region/city` | Region and city UTC offset | [UTC region/city offset values](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones){:target="_blank"}
-
-### PSET tuples
-
-`tuples_only` toggles relates to `output CSV`
-
-| Output | Query output |
-|---|---|
-| Regular | * CSV column headers<br/>* titles<br/>* Various footers |
-| tuples_only | Table data |
-
 ## Examples
-
-### Change query result orientation
-
-```
-\pset expanded on
-```
-
-Select statement:
-```sql
-select * from products;
-```
-
-Output:
-```sql
- _id      | 1
- prodlist | pen
- price    | 2.50
- stock    | NULL
- _id      | 2
- prodlist | pencil
- price    | 0.50
- stock    | NULL
- _id      | 3
- prodlist | playpen
- price    | 52.50
- stock    | NULL
- _id      | 4
- prodlist | gold-plated earplugs
- price    | 122.50
- stock    | NULL
-```
-
-### Change fbsql time-zone
-
-```
-\pset location 'Australia/Melbourne'
-```
 
 ## Further information
 

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -1,5 +1,5 @@
 ---
-title: PSET query output flags
+title: Output flags
 layout: default
 parent: CLI SQL tool
 grand_parent: Tools

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -61,9 +61,7 @@ fbsql output can be configured from the command-line or fbsql interface.
 
 ## Examples
 
-### Create new directory and output query results to file
-
-Create directory and open it:
+## Create directory and open
 
 ```
 \! mkdir newfolder
@@ -71,7 +69,7 @@ Create directory and open it:
 
 ```
 
-Output query results to file and verify existence
+## Output query results to file
 
 ```
 \out output-test.sql
@@ -79,18 +77,28 @@ Output query results to file and verify existence
 output-test.sql
 ```
 
-Run query and verify output saved to correct file:
+## Write comment to file
+
+```
+\qecho Testing 1,2,3
+\! cat output-test.sql
+Testing 1,2,3
+```
+
+## Run query and verify output saved to correct file
 
 ```
 select * from products;
 \! cat output-test.sql
 
+Testing 1,2,3
  _id | item                 | price  | stock
 -----+----------------------+--------+-------
    1 | pen                  | 2.50   | NULL
    2 | pencil               | 0.50   | NULL
    3 | playpen              | 52.50  | NULL
    4 | gold-plated earplugs | 122.50 | NULL
+(0 rows)
 ```
 
 ## Further information

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -8,11 +8,7 @@ nav_order: 12
 
 # fbsql output flags
 
-fbsql output can be configured from the command-line or fbsql interface to:
-* direct CLI and interface history to a new directory
-* change the working directory
-* create a file to output SQL query results and comments
-*
+{% include /fbsql/fbsql-output-flags-summary.md %}
 
 ## Before you begin
 

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -59,9 +59,8 @@ fbsql output can be configured from the command-line or fbsql interface.
 
 {% include /fbsql/fbsql-query-buffer-extra.md %}
 
-## Examples
-
 ## Further information
 
+* [PSET SQL query output formatting reference](/docs/tools/fbsql/fbsql-query-output-format)
 * [Learn about RFC-4180 quoting rules](https://www.rfc-editor.org/rfc/rfc4180){:target="_blank"}
 * [Create products table](/docs/sql-guide/statements/statement-table-create#create-table-with-decimal-data-type)

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -6,9 +6,13 @@ grand_parent: Tools
 nav_order: 12
 ---
 
-# fbsql output flags reference
+# fbsql output flags
 
-fbsql output can be configured from the command-line or fbsql interface.
+fbsql output can be configured from the command-line or fbsql interface to:
+* direct CLI and interface history to a new directory
+* change the working directory
+* create a file to output SQL query results and comments
+*
 
 ## Before you begin
 
@@ -22,7 +26,6 @@ fbsql output can be configured from the command-line or fbsql interface.
 (<meta-prefix>)
   [--history-path="<directory-name>"] |
   [cd [<directory-name>]] |
-  [[i|include] <filename.sql>]
   [[o | out] <query-output-filename>] |
   [qecho <text>] |
   [warn <text>]
@@ -42,7 +45,6 @@ fbsql output can be configured from the command-line or fbsql interface.
 | Flag | Description | Additional information |
 |---|---|---|
 | `cd [<directory-name>]` | Set fbsql file directory to $home or specified directory | Default is Directory fbsql started |
-{% include /fbsql/fbsql-interface-run-file-content.md %}
 
 ## Write text to output
 

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -59,6 +59,40 @@ fbsql output can be configured from the command-line or fbsql interface.
 
 {% include /fbsql/fbsql-query-buffer-extra.md %}
 
+## Examples
+
+### Create new directory and output query results to file
+
+Create directory and open it:
+
+```
+\! mkdir newfolder
+\cd newfolder
+
+```
+
+Output query results to file and verify existence
+
+```
+\out output-test.sql
+\! ls
+output-test.sql
+```
+
+Run query and verify output saved to correct file:
+
+```
+select * from products;
+\! cat output-test.sql
+
+ _id | item                 | price  | stock
+-----+----------------------+--------+-------
+   1 | pen                  | 2.50   | NULL
+   2 | pencil               | 0.50   | NULL
+   3 | playpen              | 52.50  | NULL
+   4 | gold-plated earplugs | 122.50 | NULL
+```
+
 ## Further information
 
 * [PSET SQL query output formatting reference](/docs/tools/fbsql/fbsql-query-output-format)

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -1,5 +1,5 @@
 ---
-title: fbsql output flags
+title: PSET query output flags
 layout: default
 parent: CLI SQL tool
 grand_parent: Tools

--- a/docs/tools/fbsql/fbsql-config-output.md
+++ b/docs/tools/fbsql/fbsql-config-output.md
@@ -1,14 +1,14 @@
 ---
-title: FBSQL output flags
+title: fbsql output flags
 layout: default
 parent: CLI SQL tool
 grand_parent: Tools
 nav_order: 12
 ---
 
-# FBSQL output flags reference
+# fbsql output flags reference
 
-FBSQL output can be configured from the command-line or FBSQL interface.
+fbsql output can be configured from the command-line or fbsql interface.
 
 ## Before you begin
 
@@ -36,13 +36,13 @@ FBSQL output can be configured from the command-line or FBSQL interface.
 
 | Flag | Description | Default |
 |---|---|---|
-| `--history-path="<directory-name>"` | Save CLI and FBSQL interface execution history to new folder | `<user-home>.featurebase/fbsql_history` |
+| `--history-path="<directory-name>"` | Save CLI and fbsql interface execution history to new folder | `<user-home>.featurebase/fbsql_history` |
 
 ## File output
 
 | Flag | Description | Additional information |
 |---|---|---|
-| `cd [<directory-name>]` | Set FBSQL file directory to $home or specified directory | Default is Directory FBSQL started |
+| `cd [<directory-name>]` | Set fbsql file directory to $home or specified directory | Default is Directory fbsql started |
 {% include /fbsql/fbsql-interface-run-file-content.md %}
 
 ## Write text to output
@@ -50,18 +50,18 @@ FBSQL output can be configured from the command-line or FBSQL interface.
 | Flag | Description |
 |---|---|
 | `[o | out] <query-output-filename>` | Define existing file to output query results |
-| `echo <text>` | Output `<text>` to FBSQL interface |
+| `echo <text>` | Output `<text>` to fbsql interface |
 | `qecho <text>` | Output `<text>` to file defined by `\[o|output <output-filename>]` |
-| `warn <text>` | Output `<text>` to FBSQL standard error channel |
+| `warn <text>` | Output `<text>` to fbsql standard error channel |
 
 ## PSET prefix
 
-PSET flags can be executed from the CLI or FBSQL interface:
+PSET flags can be executed from the CLI or fbsql interface:
 
 | Interface | Prefix | Structure | Example |
 |---|---|---|---|
 | CLI | `fbsql [-P|--pset] <pset-meta-commands>` | PSET output flags structured as `flag="value"` | `fbsql --P border="1"` |
-| FBSQL | `\pset <pset-meta-commands>` | Valid sequence of PSET output flag, argument and value if required | `\pset border 2` |
+| fbsql | `\pset <pset-meta-commands>` | Valid sequence of PSET output flag, argument and value if required | `\pset border 2` |
 
 ## PSET output flags
 
@@ -170,7 +170,7 @@ Output:
  stock    | NULL
 ```
 
-### Change FBSQL time-zone
+### Change fbsql time-zone
 
 ```
 \pset location 'Australia/Melbourne'

--- a/docs/tools/fbsql/fbsql-connect-cloud-db.md
+++ b/docs/tools/fbsql/fbsql-connect-cloud-db.md
@@ -6,9 +6,9 @@ grand_parent: Tools
 nav_order: 2
 ---
 
-# How do I login to a FeatureBase cloud database in FBSQL?
+# How do I login to a FeatureBase cloud database in fbsql?
 
-Login to your FeatureBase cloud database when you startup FBSQL.
+Login to your FeatureBase cloud database when you startup fbsql.
 
 ## Before you begin
 
@@ -68,7 +68,7 @@ Login to your FeatureBase cloud database when you startup FBSQL.
 
 ### Load data from data source
 
-* [Learn how to use FBSQL to load data from an external data source](/docs/tools/fbsql/fbsql-loaders)
+* [Learn how to use fbsql to load data from an external data source](/docs/tools/fbsql/fbsql-loaders)
 
 ## Additional information
 

--- a/docs/tools/fbsql/fbsql-connect-com-db.md
+++ b/docs/tools/fbsql/fbsql-connect-com-db.md
@@ -6,9 +6,9 @@ grand_parent: Tools
 nav_order: 3
 ---
 
-# How do I connect to a FeatureBase Community database with FBSQL?
+# How do I connect to a FeatureBase Community database with fbsql?
 
-Connect to a FeatureBase Community database with FBSQL.
+Connect to a FeatureBase Community database with fbsql.
 
 ## Before you begin
 
@@ -35,7 +35,7 @@ Connect to a FeatureBase Community database with FBSQL.
 ## Database connection flags
 
 {: .note}
-FBSQL automatically connects to a local instance of FeatureBase Community
+fbsql automatically connects to a local instance of FeatureBase Community
 
 | Argument | Description | Requires | Default | Additional information |
 |---|---|---|---|
@@ -51,7 +51,7 @@ FBSQL automatically connects to a local instance of FeatureBase Community
 
 ### Load data from data source
 
-* [Learn how to use FBSQL to load data from an external data source](/docs/tools/fbsql/fbsql-loaders)
+* [Learn how to use fbsql to load data from an external data source](/docs/tools/fbsql/fbsql-loaders)
 
 ## Additional information
 

--- a/docs/tools/fbsql/fbsql-home.md
+++ b/docs/tools/fbsql/fbsql-home.md
@@ -43,7 +43,13 @@ Run SQL queries in the fbsql interface or using text files:
 
 ## How do I format SQL query output?
 
-fbsql meta-commands give you full control over query output:
+{% include /fbsql/fbsql-query-formatting-summary.md %}
+
+* [fbsql query result reference](/docs/tools/fbsql/fbsql-query-output-format)
+
+## How do I change other output settings?
+
+{% include /fbsql/fbsql-output-flags-summary.md %}
 
 * [fbsql output reference](/docs/tools/fbsql/fbsql-config-output)
 

--- a/docs/tools/fbsql/fbsql-home.md
+++ b/docs/tools/fbsql/fbsql-home.md
@@ -9,9 +9,9 @@ has_toc: false
 
 # How do I run SQL queries from the command-line?
 
-The FBSQL Command Line Interface tool for Linux and MacOS systems supports:
+The fbsql Command Line Interface tool for Linux and MacOS systems supports:
 * API-key and user authenticated connections to FeatureBase databases
-* SQL statements input via text files or the FBSQL interface
+* SQL statements input via text files or the fbsql interface
 * meta-commands to control output and task scripting and automation
 
 ## Before you begin
@@ -19,16 +19,16 @@ The FBSQL Command Line Interface tool for Linux and MacOS systems supports:
 * [Learn about "docopt" notation standards used in this guide](http://docopt.org/){:target="_blank"}
 {% include /fbsql/fb-db-create.md %}
 
-## How do I install or upgrade FBSql?
+## How do I install or upgrade fbsql?
 
-* [Learn How To Install or upgrade FBSQL](/docs/tools/fbsql/fbsql-install)
+* [Learn How To Install or upgrade fbsql](/docs/tools/fbsql/fbsql-install)
 
-## How do I open and quit the FBSQL interface?
+## How do I open and quit the fbsql interface?
 
 | Task | Actions |
 |---|---|
-| Open FBSQL interface | * Open a CLI<br/>* Enter `fbsql` |
-| Quit the FBSQL interface | `\q` or `\quit` at the `=#` prompt |
+| Open fbsql interface | * Open a CLI<br/>* Enter `fbsql` |
+| Quit the fbsql interface | `\q` or `\quit` at the `=#` prompt |
 
 ## How do I connect to a FeatureBase database?
 
@@ -37,17 +37,17 @@ The FBSQL Command Line Interface tool for Linux and MacOS systems supports:
 
 ## How do I run SQL queries?
 
-Run SQL queries in the FBSQL interface or using text files:
+Run SQL queries in the fbsql interface or using text files:
 
-* [Learn how to run SQL on FBSQL](/docs/tools/fbsql/fbsql-running-sql)
+* [Learn how to run SQL on fbsql](/docs/tools/fbsql/fbsql-running-sql)
 
 ## How do I format SQL query output?
 
-FBSQL meta-commands give you full control over query output:
+fbsql meta-commands give you full control over query output:
 
-* [FBSQL output reference](/docs/tools/fbsql/fbsql-config-output)
+* [fbsql output reference](/docs/tools/fbsql/fbsql-config-output)
 
 ## Further information
 
 * [SQL Guide](/docs/sql-guide/sql-guide-home)
-* [Learn about FBSQL loaders](/docs/tools/fbsql/fbsql-loaders)
+* [Learn about fbsql loaders](/docs/tools/fbsql/fbsql-loaders)

--- a/docs/tools/fbsql/fbsql-install.md
+++ b/docs/tools/fbsql/fbsql-install.md
@@ -9,7 +9,7 @@ nav_order: 1
 
 fbsql is provided as a tool for anyone who downloads the FeatureBase source code from GitHub.
 
-The application will run natively on any Linux or MacOS operating system. For Windows machines, the system can be setup and run on a Linux virtual machine.
+The application will run natively on any Linux or MacOS operating system. For Windows machines, the system can be installed and run on a Linux virtual machine.
 
 ## Before you begin
 
@@ -23,7 +23,7 @@ The application will run natively on any Linux or MacOS operating system. For Wi
   * [Install make](https://www.gnu.org/software/make/){:target="_blank"}
   * Delete earlier installations at the CLI with `rm -rf fbsql`
 
-## Step 1 - Setup installation directory
+## Step 1 - Create installation directory
 
 * Open a CLI on your computer.
 * Run `mkdir fbsql`.

--- a/docs/tools/fbsql/fbsql-install.md
+++ b/docs/tools/fbsql/fbsql-install.md
@@ -1,19 +1,19 @@
 ---
-title: Install or upgrade FBSQL
+title: Install or upgrade fbsql
 layout: default
 parent: CLI SQL tool
 grand_parent: Tools
 nav_order: 1
 ---
-# How do I install or upgrade the FBSQL CLI?
+# How do I install or upgrade the fbsql CLI?
 
-FBSQL is provided as a tool for anyone who downloads the FeatureBase source code from GitHub.
+fbsql is provided as a tool for anyone who downloads the FeatureBase source code from GitHub.
 
 The application will run natively on any Linux or MacOS operating system. For Windows machines, the system can be setup and run on a Linux virtual machine.
 
 ## Before you begin
 
-* [Learn about FBSQL](/docs/tools/fbsql/fbsql-home)
+* [Learn about fbsql](/docs/tools/fbsql/fbsql-home)
 * Setup Linux or MacOS installation environment:
   * Obtain administrator permissions
   * Verify network settings allow access to your FeatureBase database
@@ -28,7 +28,7 @@ The application will run natively on any Linux or MacOS operating system. For Wi
 * Open a CLI on your computer.
 * Run `mkdir fbsql`.
 
-## Step 2 - clone the repository and install FBSQL
+## Step 2 - clone the repository and install fbsql
 
 * CD to `fbsql` then clone the FeatureBase code repository:
 
@@ -43,6 +43,6 @@ make install-fbsql
 
 ## Further information
 
-* [Learn how to connect to a Cloud database with FBSQL](/docs/tools/fbsql/fbsql-connect-cloud-db)
-* [Learn how to connect to a Community database with FBSQL](/docs/tools/fbsql/fbsql-connect-com-db)
-* [Learn how to run SQL commands with FBSQL](/docs/tools/fbsql/fbsql-running-sql)
+* [Learn how to connect to a Cloud database with fbsql](/docs/tools/fbsql/fbsql-connect-cloud-db)
+* [Learn how to connect to a Community database with fbsql](/docs/tools/fbsql/fbsql-connect-com-db)
+* [Learn how to run SQL commands with fbsql](/docs/tools/fbsql/fbsql-running-sql)

--- a/docs/tools/fbsql/fbsql-loaders-impala.md
+++ b/docs/tools/fbsql/fbsql-loaders-impala.md
@@ -64,7 +64,7 @@ CREATE TABLE tbl (
     idsetf idset);
 ```
 
-FBSQL configuration file pointed to by `--loader-impala`:
+fbsql configuration file pointed to by `--loader-impala`:
 ```toml
 table = "tbl"
 query = "select idkey, intf, stringf, idf, stringsetf, idsetf from testdb.impala_table;"

--- a/docs/tools/fbsql/fbsql-loaders-kafka.md
+++ b/docs/tools/fbsql/fbsql-loaders-kafka.md
@@ -66,7 +66,7 @@ Sample Kafka Message:
 }
 ```
 
-FBSQL configuration file pointed to by `--loader-kafka`:
+fbsql configuration file pointed to by `--loader-kafka`:
 ```toml
 hosts = ["localhost:9092"]
 group = "grp"

--- a/docs/tools/fbsql/fbsql-loaders-postgres.md
+++ b/docs/tools/fbsql/fbsql-loaders-postgres.md
@@ -65,7 +65,7 @@ CREATE TABLE tbl (
     idsetf idset);
 ```
 
-FBSQL configuration file pointed to by `--loader-postgres`:
+fbsql configuration file pointed to by `--loader-postgres`:
 ```toml
 table = "tbl"
 query = "select idkey, intf, stringf, idf, stringsetf, idsetf from postgres_table;"

--- a/docs/tools/fbsql/fbsql-loaders.md
+++ b/docs/tools/fbsql/fbsql-loaders.md
@@ -1,12 +1,12 @@
 ---
-title: Import data using FBSQL
+title: Import data using fbsql
 layout: default
 parent: CLI SQL tool
 grand_parent: Tools
 nav_order: 20
 ---
 
-# Define a datasource with FBSQL loaders
+# Define a datasource with fbsql loaders
 
 The `fbsql-loader` command can be run from the CLI to:
 * read data from a specified Impala, Kafka or Postgres data source
@@ -30,7 +30,7 @@ fbsql
 
 | Argument | Description | Additional information |
 |---|---|---|
-| `<db-connection-string>` | FBSQL connection string to FeatureBase database | * [FBSQL connect to FeatureBase Cloud](/docs/tools/fbsql/fbsql-connect-cloud-db)<br/>* [FBSQL connect to FeatureBase Community](/docs/tools/fbsql/fbsql-connect-com-db) |
+| `<db-connection-string>` | fbsql connection string to FeatureBase database | * [fbsql connect to FeatureBase Cloud](/docs/tools/fbsql/fbsql-connect-cloud-db)<br/>* [fbsql connect to FeatureBase Community](/docs/tools/fbsql/fbsql-connect-com-db) |
 | `--loader-impala` | Designate a configuration file containing Impala database credentials FeatureBase will read from. | [Load Impala Data With fbsql](/docs/tools/fbsql/fbsql-loaders-impala) |
 | `--loader-kafka` | Designate a configuration file containing Kafka Avro JSON files | [Load Kafka Data With fbsql](/docs/tools/fbsql/fbsql-loaders-kafka) |
 | `--loader-postgres` | Run fbsql in non-interactive mode to load data from PostgreSQL. | [Load PostgreSQL Data With fbsql](/docs/tools/fbsql/fbsql-loaders-postgres) |

--- a/docs/tools/fbsql/fbsql-query-output-format.md
+++ b/docs/tools/fbsql/fbsql-query-output-format.md
@@ -1,5 +1,5 @@
 ---
-title: fbsql output flags
+title: SQL output flags
 layout: default
 parent: CLI SQL tool
 grand_parent: Tools

--- a/docs/tools/fbsql/fbsql-query-output-format.md
+++ b/docs/tools/fbsql/fbsql-query-output-format.md
@@ -1,0 +1,148 @@
+---
+title: fbsql output flags
+layout: default
+parent: CLI SQL tool
+grand_parent: Tools
+nav_order: 13
+---
+
+# fbsql SQL Query output formatting reference
+
+`PSET` (Print Set) meta-commands can be run before SQL queries to alter default output formatting.
+
+## Before you begin
+
+{% include /fbsql/fbsql-before-begin.md %}
+* [Learn how to run SQL queries with fbsql](/docs/tools/fbsql/fbsql-running-sql)
+{% include /fbsql/fb-db-create.md %}
+{% include /fbsql/fbsql-help-quit.md %}
+
+## Syntax
+
+```
+[ (<pset-prefix>)
+  [border [0 | 1 | 2 | 3]] |
+  [format [aligned | csv]] |
+  [location ['<tz-identifier>']] |
+  [t | tuples_only]
+]
+```
+
+## PSET prefix
+
+PSET flags can be executed from the CLI or fbsql interface:
+
+| Interface | Prefix | Structure | Example |
+|---|---|---|---|
+| CLI | `fbsql [-P|--pset] <pset-meta-commands>` | PSET output flags structured as `flag="value"` | `fbsql --P border="1"` |
+| fbsql | `\pset <pset-meta-commands>` | Valid sequence of PSET output flag, argument and value if required | `\pset border 2` |
+
+## PSET output flags
+
+| Flags | Description | Default | Additional information |
+|---|---|---|---|
+| `border [0 | 1 | 2 | 3]` | Border for table output | 1 | [PSET border values](#pset-query-border-values) |
+| `format [aligned | csv]` | Toggle query result format from column, row format to RFC 4180 standard CSV format | Aligned | [Query output format](#pset-query-result-orientation) |
+| `location ['<tz-identifier>']` | Location for query result timestamps | local time zone | [Timezone identifier](#pset-time-zone-identifier)
+| `[t | tuples_only]` | Toggle storage of multiple values in a single variable. | off | [Tuples additional](#pset-tuples) |
+
+## Additional information
+
+### PSET defaults
+
+```
+border      1
+expanded    off
+format      aligned
+location    Local
+tuples_only off
+```
+
+### PSET query border values
+
+| Value | Table border | Additional information |
+|---|---|---|
+| 0 | None | Default |
+| 1 | Internal dividing lines |  |
+| 2 | Table frame |  |
+| 3 | Latex format dividing lines between rows if Add latex format dividing lines between rows | Requires Latex |
+
+### PSET query result orientation
+
+{: .note}
+`\x [on | off]` can also be used to change result orientation
+
+| Value | Column name | Data |
+|---|---|
+| on | Left column | Right column |
+| off | Top row | Bottom rows |
+
+### PSET CSV output format
+
+* Titles and footers are not printed.
+* Header line with column names generated when `tuples_only` parameter is `off`
+* End of line characters are system-dependent:
+
+| OS | Description |EOL character |
+|---|---|---|
+| Linux<br/>MacOS | Single new-line character | `\n` |
+| Windows | Carriage return and newline sequence |`\r\n` |
+
+### PSET time-zone identifier
+
+The optional time-zone can be set as follows:
+
+| `<tz identifier>` | Description | Further information |
+|---|---|---|
+| `<none>` | Local time |  |
+| `UTC` | UTC time |  |
+| `region/city` | Region and city UTC offset | [UTC region/city offset values](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones){:target="_blank"}
+
+### PSET tuples
+
+`tuples_only` toggles relates to `output CSV`
+
+| Output | Query output |
+|---|---|
+| Regular | * CSV column headers<br/>* titles<br/>* Various footers |
+| tuples_only | Table data |
+
+## Examples
+
+
+### Change query result orientation
+
+```
+\pset expanded on
+```
+
+Select statement:
+```sql
+select * from products;
+```
+
+Output:
+```sql
+ _id      | 1
+ prodlist | pen
+ price    | 2.50
+ stock    | NULL
+ _id      | 2
+ prodlist | pencil
+ price    | 0.50
+ stock    | NULL
+ _id      | 3
+ prodlist | playpen
+ price    | 52.50
+ stock    | NULL
+ _id      | 4
+ prodlist | gold-plated earplugs
+ price    | 122.50
+ stock    | NULL
+```
+
+### Change fbsql time-zone
+
+```
+\pset location 'Australia/Melbourne'
+```

--- a/docs/tools/fbsql/fbsql-query-output-format.md
+++ b/docs/tools/fbsql/fbsql-query-output-format.md
@@ -8,7 +8,11 @@ nav_order: 13
 
 # fbsql SQL query output formatting flags
 
-`PSET` (Print Set) meta-commands can be run before SQL queries to alter default output formatting.
+`PSET` (Print Set) meta-commands alter default output formatting for SQL queries:
+* border
+* orientation
+* query result timestamp
+* toggling storage of results as variables that can be reused
 
 ## Before you begin
 
@@ -21,9 +25,10 @@ nav_order: 13
 
 ```
 [ (<pset-prefix>)
-  [border [0 | 1 | 2 | 3]] |
-  [format [aligned | csv]] |
-  [location ['<tz-identifier>']] |
+  [border (0 | 1 | 2 | 3)] |
+  [expanded (on | off)] |
+  [format (aligned | csv)] |
+  [location ('<tz-identifier>')] |
   [t | tuples_only]
 ]
 ```
@@ -41,14 +46,15 @@ PSET flags can be executed from the CLI or fbsql interface:
 
 | Flags | Description | Default | Additional information |
 |---|---|---|---|
-| `border [0 | 1 | 2 | 3]` | Border for table output | 1 | [PSET border values](#pset-query-border-values) |
-| `format [aligned | csv]` | Toggle query result format from column, row format to RFC 4180 standard CSV format | Aligned | [Query output format](#pset-query-result-orientation) |
-| `location ['<tz-identifier>']` | Location for query result timestamps | local time zone | [Timezone identifier](#pset-time-zone-identifier)
+| `border (0 | 1 | 2 | 3)` | Border for table output | 1 | [Border values](#border-values) |
+| `expanded (on | off)` | change result orientation to vertical | horizontal | [Result orientation](#query-result-orientation) |
+| `format (aligned | csv)` | Toggle query result format from column, row format to RFC 4180 standard CSV format | Aligned | [Format setting](#format-setting) |
+| `location ('<tz-identifier>')` | Location for query result timestamps | local time zone | [Timezone identifier](#time-zone-identifier)
 | `[t | tuples_only]` | Toggle storage of multiple values in a single variable. | off | [Tuples additional](#pset-tuples) |
 
 ## Additional information
 
-### PSET defaults
+### Query output defaults
 
 ```
 border      1
@@ -58,7 +64,7 @@ location    Local
 tuples_only off
 ```
 
-### PSET query border values
+### Border values
 
 | Value | Table border | Additional information |
 |---|---|---|
@@ -67,7 +73,7 @@ tuples_only off
 | 2 | Table frame |  |
 | 3 | Latex format dividing lines between rows if Add latex format dividing lines between rows | Requires Latex |
 
-### PSET query result orientation
+### Result orientation
 
 {: .note}
 `\x [on | off]` can also be used to change result orientation
@@ -77,18 +83,18 @@ tuples_only off
 | on | Left column | Right column |
 | off | Top row | Bottom rows |
 
-### PSET CSV output format
+### Format setting
 
-* Titles and footers are not printed.
+* Titles and footers are not printed
 * Header line with column names generated when `tuples_only` parameter is `off`
 * End of line characters are system-dependent:
 
-| OS | Description |EOL character |
+| OS | Description | EOL character |
 |---|---|---|
 | Linux<br/>MacOS | Single new-line character | `\n` |
 | Windows | Carriage return and newline sequence |`\r\n` |
 
-### PSET time-zone identifier
+### Time-zone identifier
 
 The optional time-zone can be set as follows:
 
@@ -98,17 +104,14 @@ The optional time-zone can be set as follows:
 | `UTC` | UTC time |  |
 | `region/city` | Region and city UTC offset | [UTC region/city offset values](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones){:target="_blank"}
 
-### PSET tuples
+### Tuples
 
-`tuples_only` toggles relates to `output CSV`
-
-| Output | Query output |
-|---|---|
-| Regular | * CSV column headers<br/>* titles<br/>* Various footers |
-| tuples_only | Table data |
+| Output | Query output | Additional information |
+|---|---|---|
+| Regular | * CSV column headers<br/>* titles<br/>* Various footers |  |
+| tuples_only | Table data | Relates to `format CSV` |
 
 ## Examples
-
 
 ### Change query result orientation
 

--- a/docs/tools/fbsql/fbsql-query-output-format.md
+++ b/docs/tools/fbsql/fbsql-query-output-format.md
@@ -6,7 +6,7 @@ grand_parent: Tools
 nav_order: 13
 ---
 
-# fbsql SQL Query output formatting reference
+# fbsql SQL query output formatting flags
 
 `PSET` (Print Set) meta-commands can be run before SQL queries to alter default output formatting.
 

--- a/docs/tools/fbsql/fbsql-query-output-format.md
+++ b/docs/tools/fbsql/fbsql-query-output-format.md
@@ -8,11 +8,7 @@ nav_order: 13
 
 # fbsql SQL query output formatting flags
 
-`PSET` (Print Set) meta-commands alter default output formatting for SQL queries:
-* border
-* orientation
-* query result timestamp
-* toggling storage of results as variables that can be reused
+{% include /fbsql/fbsql-query-formatting-summary.md %}
 
 ## Before you begin
 

--- a/docs/tools/fbsql/fbsql-running-sql.md
+++ b/docs/tools/fbsql/fbsql-running-sql.md
@@ -33,7 +33,6 @@ This reference explains fbsql flags relating to database connections and schema
     [ t|timing [on|off] ] |
     [ p|print ] |
     [ r|reset ] |
-    [ <pset-query-output-flags> ]
 ]
 <sql-query>
 ```
@@ -82,10 +81,6 @@ This reference explains fbsql flags relating to database connections and schema
 | `[set|unset] <variable-name>` | Set or unset named variable |  |
 | `set <variable-name> <value>...` | Set a variable name and value. Multiple values are concatenated. | [SET variable names](#set-variable-names) |
 
-## PSET query output flags
-
-* [PSET query output flags](/docs/tools/fbsql/fbsql-config-output#pset-prefix)
-
 ## SQL query syntax
 
 * [SQL guide](/docs/sql-guide/sql-guide-home)
@@ -108,6 +103,12 @@ Aliases are case sensitive and can be inserted into statements in two ways:
 |---|---|
 | Single | `:'<variable-name>'` |
 | Double | `:"<variable-name>"` |
+
+### Query output formatting
+
+Query output can be formatted using `PSET` (Print Set) meta flags.
+
+* [PSET query output formatting reference](/docs/tools/fbsql/fbsql-query-output-format)
 
 ## Examples
 
@@ -173,3 +174,4 @@ Query with variable
 ## Further information
 
 * [SQL Guide](/docs/sql-guide/sql-guide-home)
+* [PSET SQL Query output formatting](/docs/tools/fbsql/fbsql-query-output-format)

--- a/docs/tools/fbsql/fbsql-running-sql.md
+++ b/docs/tools/fbsql/fbsql-running-sql.md
@@ -6,11 +6,11 @@ grand_parent: Tools
 nav_order: 4
 ---
 
-# How do I run SQL queries with FBSQL?
+# How do I run SQL queries with fbsql?
 
-Valid SQL queries can be run directly in the FBSQL interface and via files in accessible directories.
+Valid SQL queries can be run directly in the fbsql interface and via files in accessible directories.
 
-This reference explains FBSQL flags relating to database connections and schema
+This reference explains fbsql flags relating to database connections and schema
 
 ## Before you begin
 
@@ -71,7 +71,7 @@ This reference explains FBSQL flags relating to database connections and schema
 
 | Flag | Description |
 |---|---|
-| `[p | print]` | Display most recent query or query buffer to FBSQL interface followed by a newline |
+| `[p | print]` | Display most recent query or query buffer to fbsql interface followed by a newline |
 | `[r | reset]` | Reset query buffer |
 
 ## Set variable flags

--- a/docs/tools/fbsql/fbsql-running-sql.md
+++ b/docs/tools/fbsql/fbsql-running-sql.md
@@ -28,7 +28,7 @@ This reference explains fbsql flags relating to database connections and schema
     [ l|list ] |
     [ set <variable-name> [variable-value,...] ] |
     [ unset <variable-name> ] |
-    [ i|include <filename.sql> ] |
+    [ i|include <filename> ] |
     [ watch <seconds> ] |
     [ t|timing [on|off] ] |
     [ p|print ] |

--- a/docs/tools/tools-home.md
+++ b/docs/tools/tools-home.md
@@ -20,5 +20,5 @@ FeatureBase provides a number of tools that allow you to interact with data stor
 | Tool | Description | Supports | Additional information |
 |---|---|---|
 | Cloud API | API tool to perform tasks on a FeatureBase Cloud database | FeatureBase SQL queries | [FeatureBase Cloud API](https://api-docs-featurebase-cloud.redoc.ly/){:target="_blank"} |
-| FBSql CLI tool | Command-line tool used to run SQL queries | FeatureBase SQL queries | [FBSQL tool](/docs/tools/fbsql/fbsql-home) |
+| FBSql CLI tool | Command-line tool used to run SQL queries | FeatureBase SQL queries | [fbsql tool](/docs/tools/fbsql/fbsql-home) |
 | Python client library | A python library of components required by python applications to access FeatureBase databases | [Python client library](/docs/tools/python-client-library/python-client-library-home) |


### PR DESCRIPTION
This PR was created to address issues brought up by @travisturner on Slack.


Some things also to note:
* I'm coming at this from the POV of a user who's never used the system, so I'm attempting to make the docs as unambiguous as possible.
* The approach is the same as that taken with the Community Ingest docs, where instead of one big bucket of flags and whatnot, they're divided into high level groupings based on the assumption users will want to do specific things (e.g., connect to a db, run queries, output results and whatnot). 

## The thread

URL: https://moleculacorp.slack.com/archives/D04QW9A8TM1/p1693234779116399

## Message annotations

I've annotated the copied message below as follows:

* FIXED = yep, agree, no wukkas, etc
* TODO = to be fixed, no discussion needed (will change to FIXED)
* see comment = comments below

```
Hi Lisa,
I just reviewed the latest fbsql docs and I feel like there have been some regressions.

For context, we try to follow the general usage of PostgreSQL’s interactive terminal, the docs for which can be found [here](https://www.postgresql.org/docs/current/app-psql.html). 

Speaking as an engineer, the psql docs are far easier to navigate and understand than what we have for fbsql (which, for the most part, works exactly the same way). The psql docs also contain a section describing “Meta-Commands”, the spirit of which I think is useful to understand.  **see comment**

Some general things that I stumbled over when reviewing our docs:

*    The section titled “CLI flag Prefix” is confusing to me; I don’t understand why we’re conflating bash commands and fbsql meta-commands into something called a “flag prefix”? **see comment**
*   The section titled “Meta-command flag prefix” is also confusing to me; again we seem to be conflating meta-commands with bash, command line arguments. Also, meta-commands aren’t separated by \, rather, they are denoted by \ at the beginning of the command. **see comment**
*   This format -[c|-command] is something I have not seen before. Why not [-c|--command]? (FIXED)
*    fbsql should always be lowercase. I see it both FBSQL and FBSql, neither of which is correct. (FIXED)
*    The use of “pset” next to and/or in addition to “output” is confusing. “pset” stands for “print set”; it denotes how the output should be printed (i.e. its format). “output” generally refers to where the output should be printed (i.e. to the terminal, to a file, etc). **see comment**
*    The TOML configuration file for fbsql contains more than connection options, so calling it a “TOML connection file” is confusing. (FIXED)
*    While I appreciate the usage docs being split into various sections, it’s not clear how to navigate these pages when the information is not in an obvious place. For example, the “Connect to cloud/community db” pages have a section called “Optional arguments” which describe the -f flag for executing commands located in a file. That functionality seems to align more with “Running SQL queries” than connecting to a database (but note, commands run from a file can contain meta-commands, so we should be careful where we imply something is always a “SQL query”). **see comment**

Also, it looks like more instances of “setup” being used as a verb have snuck in. See [this PR](https://github.com/FeatureBaseDB/featurebase-docs/pull/65) for previous fixes. (FIXED)
```