### PR TITLE
Added cloud status to top navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,9 +28,9 @@ aux_links_new_tab: true
   # Anchor text and hyperlinks that appear in top of page nav
 aux_links:
   Featurebase home: https://featurebase.com
+  Cloud Status: https://status.featurebase.com/
   Glossary: /docs/concepts/glossary
   API docs: https://api-docs-featurebase-cloud.redoc.ly/
-  Docs on GitHub: https://github.com/FeatureBaseDB/featurebase-docs
   Contact us: https://www.featurebase.com/contact-us
 
 # permalink info found on https://jekyllrb.com/docs/permalinks/


### PR DESCRIPTION
Which I learned of in an email regarding the outage.