### PR TITLE
Update support url

### DIFF
--- a/_includes/contact-support.md
+++ b/_includes/contact-support.md
@@ -1,1 +1,1 @@
-[Contact FeatureBase Support on Discord](https://discord.com/invite/bSBYjDbUUb){:target=_blank}
+[Contact FeatureBase Support](https://featurebase.com/slack){:target=_blank}

--- a/_includes/contact-support.md
+++ b/_includes/contact-support.md
@@ -1,1 +1,1 @@
-[Contact FeatureBase Support](https://featurebase.com/slack){:target=_blank}
+[Contact FeatureBase Support](https://featurebase.com/slack){:target="_blank"}

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,8 +1,8 @@
 <!-- custom footer automatically appears at the bottom of each page -->
 
 <p>
-  <span class="material-icons md-18">support_agent</span> <a href="https://featurebase.com/slack" target="_blank">Contact FeatureBase support</a> | <span class="material-icons md-18">bug_report</span> <a href="https://github.com/FeatureBaseDB/featurebase-docs/issues" target="_blank">Raise help issue </a> | <span class="material-icons md-18">outgoing_mail</span> <a href="https://www.featurebase.com/contact-us" target="_blank">Contact FeatureBase</a>
+  <span class="material-icons md-18">support_agent</span> <a href="https://featurebase.com/slack" target="_blank">Contact FeatureBase support</a> | <span class="material-icons md-18">outgoing_mail</span> <a href="https://www.featurebase.com/contact-us" target="_blank">Contact FeatureBase</a>
 </p>
 <p>
-  Copyright &copy; 2023 <a href="https://featurebase.com" target="_blank" rel="noopener">FeatureBase</a>. All rights reserved.
+  &copy; {{ site.time | date: '%Y' }} <a href="https://featurebase.com" target="_blank" rel="noopener">FeatureBase</a>. All rights reserved.
 </p>

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -4,5 +4,5 @@
   <span class="material-icons md-18">support_agent</span> <a href="https://featurebase.com/slack" target="_blank">Contact FeatureBase support</a> | <span class="material-icons md-18">outgoing_mail</span> <a href="https://www.featurebase.com/contact-us" target="_blank">Contact FeatureBase</a>
 </p>
 <p>
-  &copy; {{ site.time | date: '%Y' }} <a href="https://featurebase.com" target="_blank" rel="noopener">FeatureBase</a>. All rights reserved.
+  &copy; {{ site.time | date: '%Y' }} <a href="https://featurebase.com" target="_blank" rel="noopener">FeatureBase</a>, all rights reserved.
 </p>

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,7 +1,7 @@
 <!-- custom footer automatically appears at the bottom of each page -->
 
 <p>
-  <span class="material-icons md-18">support_agent</span> <a href="https://discord.com/invite/bSBYjDbUUb" target="_blank">Get support on Discord</a> | <span class="material-icons md-18">bug_report</span> <a href="https://github.com/FeatureBaseDB/featurebase-docs/issues" target="_blank">Raise help issue </a> | <span class="material-icons md-18">outgoing_mail</span> <a href="https://www.featurebase.com/contact-us" target="_blank">Contact FeatureBase</a>
+  <span class="material-icons md-18">support_agent</span> <a href="https://featurebase.com/slack" target="_blank">Contact FeatureBase support</a> | <span class="material-icons md-18">bug_report</span> <a href="https://github.com/FeatureBaseDB/featurebase-docs/issues" target="_blank">Raise help issue </a> | <span class="material-icons md-18">outgoing_mail</span> <a href="https://www.featurebase.com/contact-us" target="_blank">Contact FeatureBase</a>
 </p>
 <p>
   Copyright &copy; 2023 <a href="https://featurebase.com" target="_blank" rel="noopener">FeatureBase</a>. All rights reserved.

--- a/docs/cloud/cloud-databases/cloud-db-manage.md
+++ b/docs/cloud/cloud-databases/cloud-db-manage.md
@@ -91,7 +91,7 @@ has_toc: false
 FeatureBase automatically backs-up your databases every 24 hours.
 
 {: .note}
-[Contact FeatureBase Support on Discord](https://discord.com/invite/bSBYjDbUUb){:target="_blank"} to ask questions or to get help restoring a backup.
+{% include contact-support.md%} for help with backups
 
 ## How do I drop my database?
 

--- a/docs/cloud/cloud-databases/cloud-db-states.md
+++ b/docs/cloud/cloud-databases/cloud-db-states.md
@@ -51,13 +51,10 @@ You can query the database state in the following ways:
 
 ### Error states
 
-The database is unavailable when it has the following states:
+{: .note}
+* {% include contact-support.md%} for help with error states.
 
 | Database Status | Definition |
 |---|---|
 | FROZEN | An error has occurred with a database backup |
 | FAILED | Database is in unrecoverable state as a result of failed provisioning of resources, restoration from backup or deletion |
-
-## Further information
-
-* {% include contact-support.md%}

--- a/docs/cloud/cloud-databases/cloud-db-states.md
+++ b/docs/cloud/cloud-databases/cloud-db-states.md
@@ -51,12 +51,13 @@ You can query the database state in the following ways:
 
 ### Error states
 
-{: .note}
-[Contact FeatureBase Support on Discord for help](https://discord.com/invite/bSBYjDbUUb){:target="_blank"}
-
 The database is unavailable when it has the following states:
 
 | Database Status | Definition |
 |---|---|
 | FROZEN | An error has occurred with a database backup |
 | FAILED | Database is in unrecoverable state as a result of failed provisioning of resources, restoration from backup or deletion |
+
+## Further information
+
+* {% include contact-support.md%}

--- a/docs/cloud/cloud-org/cloud-org-billing.md
+++ b/docs/cloud/cloud-org/cloud-org-billing.md
@@ -30,3 +30,10 @@ Billing follows a monthly cycle that starts on the date your organization was cr
 ## Questions about your bill
 
 * {% include contact-support.md %}
+
+## How do I generate an invoice?
+
+* Click Configuration.
+* Find your invoice in the **Invoices** panel, bottom right.
+* Click **PDF** under **Export As**.
+* Choose a folder to save the PDF.

--- a/docs/cloud/cloud-org/cloud-org-billing.md
+++ b/docs/cloud/cloud-org/cloud-org-billing.md
@@ -8,26 +8,24 @@ nav_order: 5
 
 # How do I manage payments and billing for my organization?
 {: .no_toc }
-Learn how to manage payments and invoices for before and after your trial expires.
-
-{% include page-toc.md %}
+Learn how to manage payments and invoices after your trial expires.
 
 ## Before you begin
 
 {% include /cloud/cloud-before-begin.md %}
 
-* [Database usage pricing](https://www.featurebase.com/pricing){:target="\_blank:}
+* [Database usage pricing](https://www.featurebase.com/pricing){:target="_blank:}
 * [Available database sizes](https://docs.featurebase.com/docs/cloud/cloud-databases/cloud-db-shape/)
 * [Upgrade to a paid account](/docs/cloud/cloud-org/cloud-org-upgrade-to-paid/)
 
 ## Billing cycle
 
-* Billing follows a monthly cycle that starts on the date your organization was created
+Billing follows a monthly cycle that starts on the date your organization was created.
 
 ## Paying your bill
 
 * An invoice is issued at the end of the billing cycle and your payment method is automatically charged
-* An email confirmation will be sent with the invoice and payment details to the email that created the organization
+* An email confirmation is sent to the email used to create the organization with an invoice and payment details
 
 ## Questions about your bill
 

--- a/docs/cloud/cloud-org/cloud-org-manage.md
+++ b/docs/cloud/cloud-org/cloud-org-manage.md
@@ -37,4 +37,4 @@ has_toc: false
 
 ## How do I upgrade my organization to a paid account?
 
-* [Learn how to upgrade your organization to paid](/docs/cloud/cloud-org/cloud-org-upgrade-to-paid)
+* [Learn how to upgrade your organization account](/docs/cloud/cloud-org/cloud-org-upgrade-to-paid)

--- a/docs/cloud/cloud-org/cloud-org-update-billing.md
+++ b/docs/cloud/cloud-org/cloud-org-update-billing.md
@@ -11,7 +11,7 @@ nav_order: 2
 
 {% include /cloud-org/cloud-summary-billing-contact.md %}
 
-{% include page-toc.md %}
+Your billing address is included on billing invoices and should be kept up-to-date.
 
 ## Before you begin
 

--- a/docs/cloud/cloud-org/cloud-org-update-tech-contact.md
+++ b/docs/cloud/cloud-org/cloud-org-update-tech-contact.md
@@ -11,8 +11,6 @@ nav_order: 3
 
 {% include /cloud-org/cloud-summary-tech-contact.md %}
 
-{% include page-toc.md %}
-
 ## Before you begin
 
 {% include /cloud-users/cloud-user-admin-role-needed.md %}

--- a/docs/cloud/cloud-org/cloud-org-upgrade-to-paid.md
+++ b/docs/cloud/cloud-org/cloud-org-upgrade-to-paid.md
@@ -9,8 +9,6 @@ nav_order: 4
 # How do I pay for my Database usage?
 {: .no_toc }
 
-{% include page-toc.md %}
-
 ## Before you begin
 
 {% include /cloud/cloud-before-begin.md %}
@@ -36,4 +34,4 @@ nav_order: 4
 
 ## Further information
 
-* [Manage your bill](/docs/cloud/cloud-org/cloud-org-billing/)
+* [Learn how to manage your bill](/docs/cloud/cloud-org/cloud-org-billing/)

--- a/docs/cloud/cloud-troubleshooting/issue-creating-database.md
+++ b/docs/cloud/cloud-troubleshooting/issue-creating-database.md
@@ -19,4 +19,4 @@ Your account may be limited due to one or more of the following issues:
 
 * [Check FeatureBase Cloud status](https://status.featurebase.com/){:target="_blank"}
 * [Upgrade from a Trial to a paid account](/docs/cloud/cloud-org/cloud-org-upgrade-to-paid/)
-* [Contact the FeatureBase Support channel on Discord](https://discord.com/invite/bSBYjDbUUb){:target="_blank"}
+* {% include contact-support.md%}

--- a/docs/community/old-setup/old-community-quickstart-guide.md
+++ b/docs/community/old-setup/old-community-quickstart-guide.md
@@ -18,7 +18,7 @@ In this demonstration you will:
 3. Restore two large-scale datasets into FeatureBase
 4. Run a set of analytics queries
 
->If you run into any roadblocks or have questions, please join our [Discord](https://discord.com/invite/bSBYjDbUUb).
+>If you run into any roadblocks or have questions, please join our [Discord](https://featurebase.com/slack).
 
 ## Download FeatureBase Binary
 To download releases of FeatureBase, you must have a github account.


### PR DESCRIPTION
changed discord support url to slack, plus some small, obvious fixes.
Also automated the copyright year in the footer.