### PR TITLE
Document euclidean_distance function, add explanations

### DIFF
--- a/docs/sql-guide/data-types/data-type-vector.md
+++ b/docs/sql-guide/data-types/data-type-vector.md
@@ -33,3 +33,11 @@ VECTOR({length})
 ## Examples
 
 * [CREATE TABLE with VECTOR data type](/docs/sql-guide/examples/sql-eg-table/sql-eg-table-create-cosvec-target)
+* [INSERT INTO VECTOR data type](/docs/sql-guide/examples/sql-eg-insert/sql-eg-insert-cosvec-target)
+* [SELECT FROM VECTOR data type](/docs/sql-guide/examples/sql-eg-select/sql-eg-select-from-cosvec-target)
+
+## Further information
+
+The following functions can be included in SELECT queries to measure VECTOR values:
+* [COSINE_DISTANCE function](/docs/sql-guide/functions/function_cosine_distance)
+* [EUCLIDEAN_DISTANCE function](/docs/sql-guide/functions/function_euclidean_distance)

--- a/docs/sql-guide/examples/sql-eg-select/sql-eg-select-from-cosvec-target.md
+++ b/docs/sql-guide/examples/sql-eg-select/sql-eg-select-from-cosvec-target.md
@@ -11,22 +11,30 @@ nav_exclude: true
 * [SELECT examples](/docs/sql-guide/examples/sql-eg-home/#select-examples)
 * [SELECT statement](/docs/sql-guide/statements/statement-select)
 * [COSINE_DISTANCE function](/docs/sql-guide/functions/function-cosine-distance)
+* [EUCLIDEAN_DISTANCE function](/docs/sql-guide/functions/function-euclidean-distance)
 * [CREATE TABLE cosvec-target](/docs/sql-guide/examples/sql-eg-table/sql-eg-table-create-cosvec-target)
 * [INSERT INTO cosvec-target](/docs/sql-guide/examples/sql-eg-insert/sql-eg-insert-cosvec-target)
 
-## SELECT COSINE DISTANCE()
+## Comparing the distance metrics
+
+The following example illustrates the difference in behavior between the cosine and
+euclidean distance:
 
 ```sql
-SELECT _id, description, cosine_distance(
-  [-0.027067707851529, 0.009963636286557, 0.034747183322906], cosvec-col)
-   AS rank
-   FROM cosvec-target;
+SELECT cosine_distance([1.0, 0.0], [0.0, 1.0]) as cos_1_0,
+       euclidean_distance([1.0, 0.0], [0.0, 1.0]) as euc_1_0,
+       cosine_distance([2.0, 0.0], [0.0, 2.0]) as cos_2_0,
+       euclidean_distance([2.0, 0.0], [0.0, 2.0]) as euc_2_0;
 
-id |     description     |   rank
----+---------------------+----------
- 0 | Three vector values | 1.2763582
-
+ cos_1_0 |   euc_1_0 | cos_2_0 |  euc_2_0
+---------+-----------+---------+----------
+       1 | 1.4142135 |       1 | 2.828427
 ```
+
+The cosine distance between two vectors is unaffected by their magnitude,
+and measures only the similarity of their angles. The euclidean distance
+is measuring the distance between points, rather than the angle between
+vectors.
 
 ## Further information
 

--- a/docs/sql-guide/examples/sql-eg-select/sql-eg-select-from-cosvec-target.md
+++ b/docs/sql-guide/examples/sql-eg-select/sql-eg-select-from-cosvec-target.md
@@ -15,10 +15,13 @@ nav_exclude: true
 * [CREATE TABLE cosvec-target](/docs/sql-guide/examples/sql-eg-table/sql-eg-table-create-cosvec-target)
 * [INSERT INTO cosvec-target](/docs/sql-guide/examples/sql-eg-insert/sql-eg-insert-cosvec-target)
 
-## Comparing the distance metrics
+## Comparing distance metrics
 
-The following example illustrates the difference in behavior between the cosine and
-euclidean distance:
+FeatureBase supplies two functions to measure `VECTOR` data type values:
+* **cosine_distance** measures the similarity of angles between two vectors, and is unaffected by their magnitude
+* **euclidean distance** measures the distance between points, rather than the angle between vectors
+
+The following example illustrates the difference between these measures:
 
 ```sql
 SELECT cosine_distance([1.0, 0.0], [0.0, 1.0]) as cos_1_0,
@@ -30,11 +33,6 @@ SELECT cosine_distance([1.0, 0.0], [0.0, 1.0]) as cos_1_0,
 ---------+-----------+---------+----------
        1 | 1.4142135 |       1 | 2.828427
 ```
-
-The cosine distance between two vectors is unaffected by their magnitude,
-and measures only the similarity of their angles. The euclidean distance
-is measuring the distance between points, rather than the angle between
-vectors.
 
 ## Further information
 

--- a/docs/sql-guide/functions/function-euclidean-distance.md
+++ b/docs/sql-guide/functions/function-euclidean-distance.md
@@ -1,19 +1,20 @@
 ---
-title: COSINE_DISTANCE()
+title: EUCLIDEAN_DISTANCE()
 layout: default
 parent: Functions
 grand_parent: SQL guide
 ---
-# COSINE_DISTANCE() function
+# EUCLIDEAN_DISTANCE() function
 
-`COSINE_DISTANCE()` is a mathematical function that can be performed on `VECTOR` data type columns.
-The cosine distance, sometimes called the cosine similarity, of two vectors is a measure of the
-angle between them. This gives a measure of similarity ignoring the magnitude of the vectors.
+`EUCLIDEAN_DISTANCE()` is a mathematical function that can be performed on `VECTOR` data type columns.
+The Euclidean (or Euclidian) distance between two vectors is the square root of the sum of the squares
+the pairwise differences between the vectors. This is the distance metric most commonly used when talking
+about distances between locations on a plane.
 
 ## Syntax
 
 ```sql
-COSINE_DISTANCE (<vector1>, <vector2>)
+EUCLIDEAN_DISTANCE (<vector1>, <vector2>)
 ```
 
 Vectors can be either vector literals, such as `[0.0, 1.0]` or vector expressions, such as a vector


### PR DESCRIPTION
Since we now have two distance functions, I've clarified their semantic differences a bit, and use a single shared example page for them so they can be directly contrasted.

I've also changed the description of the arguments; the functions don't care whether either argument is a column or a vector literal, just that they have vectors of the same number of dimensions. (I say "number of dimensions" rather than "length" because vectors have a length in the sense of "distance from a vector with all components 0" and I want to avoid confusion.)