### PR TITLE
resolved with single sentence

### DIFF
--- a/docs/tools/fbsql/fbsql-running-sql.md
+++ b/docs/tools/fbsql/fbsql-running-sql.md
@@ -78,7 +78,7 @@ This reference explains fbsql flags relating to database connections and schema
 | Flag | Description | Additional information |
 |---|---|---|
 | `set` | List all variable names |  |
-| `[set|unset] <variable-name>` | Set or unset named variable |  |
+| `[set|unset] <variable-name>` | Set or unset named variable | Named variables in single quotation marks are treated as string literals |
 | `set <variable-name> <value>...` | Set a variable name and value. Multiple values are concatenated. | [SET variable names](#set-variable-names) |
 
 ## SQL query syntax

--- a/docs/tools/fbsql/fbsql-running-sql.md
+++ b/docs/tools/fbsql/fbsql-running-sql.md
@@ -78,7 +78,7 @@ This reference explains fbsql flags relating to database connections and schema
 | Flag | Description | Additional information |
 |---|---|---|
 | `set` | List all variable names |  |
-| `[set|unset] <variable-name>` | Set or unset named variable | Named variables in single quotation marks are treated as string literals |
+| `[set|unset] <variable-name>` | Set or unset named variable | Named variables in single quotation marks are treated as string literals in queries |
 | `set <variable-name> <value>...` | Set a variable name and value. Multiple values are concatenated. | [SET variable names](#set-variable-names) |
 
 ## SQL query syntax


### PR DESCRIPTION
NOTE: original text was rewritten during fbsql revisions, so I've added the following to the `SET` table on line 81

> Named variables in single quotation marks are treated as string literals in queries

Hopefully this makes the whole thing clearer.